### PR TITLE
build: change package.json type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mparticle/aquarium",
   "version": "1.0.0",
-  "type": "module",
+  "main": "dist/aquarium.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
 ## Summary
 - Update the package.json type to build a release
when you define "type" : "module" (which was leftover from me messing with the local dependency inclusion), the semantic-release tool includes it's own configuration file in the release, and throws an error.  so the solution ... is to configure the package.json to point to the "main" asset of the package

 ## Testing Plan
 - Will run a release after this PR
 
 ## Reference Issue 
 - Closes https://go.mparticle.com/work/UNI-41
