### PR TITLE
chore: testing the release of 2.0 to go back to latest@main releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
## Summary
- After merging next into main we were having trouble releasing in the latest dist-tag from npm because of the way we used the next dist-tag. It's meant for breaking change releases but we were using it for minor/patch. Let's try to get a clean state for 2.0

## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
- Closes https://go.mparticle.com/work/UNI-290

BREAKING CHANGE: Starting fresh