### PR TITLE
fix: hide expand icon in global navigation lists

### DIFF
--- a/src/components/navigation/GlobalNavigation/NavigationList.tsx
+++ b/src/components/navigation/GlobalNavigation/NavigationList.tsx
@@ -18,7 +18,7 @@ export function NavigationList(props: INavigationListProps) {
       {props.items.map((item, i) => (
         <Fragment key={i}>
           {item.type === 'menu' ? (
-            <Menu key={i} className="globalNavigation__menu" items={[generateMenuItem(item, i)]} />
+            <Menu key={i} expandIcon={null} className="globalNavigation__menu" items={[generateMenuItem(item, i)]} />
           ) : (
             <NavigationItem {...item} type="link" key={i} />
           )}
@@ -37,6 +37,7 @@ function generateMenuItem(item: IGlobalNavigationItem, i: number) {
     children.push(
       ...item.children.map((linkItem, j) => ({
         ...linkItem,
+        expandIcon: null,
         key: `${String(linkItem.label)}${j}`,
         label: buildLinkFromHrefOptions(linkItem.label, linkItem.hrefOptions),
       })),


### PR DESCRIPTION
## Instructions

1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
- global navigation menu items should never show the expand arrow icon
<img width="270" alt="image" src="https://github.com/mParticle/aquarium/assets/14081357/2152eb03-7c90-4cf4-b9ce-c9eb3875dfd4">


## Testing Plan
- [x] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- Closes https://go.mparticle.com/work/REPLACEME
