### PR TITLE
feat: Allows publishing from feature branchs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.11.0-release-process.1](https://github.com/mParticle/aquarium/compare/v1.10.0...v1.11.0-release-process.1) (2024-03-29)
+
+
+### Features
+
+* allows publishing from feature branches ([eb32f58](https://github.com/mParticle/aquarium/commit/eb32f58e8b616c27c51a081e56e4e8f8d751a171))
+
 # [1.10.0](https://github.com/mParticle/aquarium/compare/v1.9.5...v1.10.0) (2024-03-29)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.10.0",
+  "version": "1.11.0-release-process.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.10.0",
+      "version": "1.11.0-release-process.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "19.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.10.0",
+  "version": "1.11.0-release-process.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,9 @@
 module.exports = {
-  branches: ['main', { name: 'dev', channel: 'dev', prerelease: 'dev' }],
+  branches: ['main', { name: 'dev', channel: 'dev', prerelease: 'dev' }, {
+    name: 'feature/*',
+    channel: 'channel-${name}',
+    prerelease: "prerelease-${name.split('/').join('-')}"
+  }],
   tagFormat: 'v${version}',
   repositoryUrl: 'https://github.com/mParticle/aquarium',
   plugins: [

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['main', { name: 'dev', channel: 'dev', prerelease: 'dev' }, {
+  branches: ['main', {
     name: 'feature/*',
     channel: 'feature',
     prerelease: "${name.split('/').slice(1).join('-').toLowerCase()}"

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,8 +1,8 @@
 module.exports = {
   branches: ['main', { name: 'dev', channel: 'dev', prerelease: 'dev' }, {
     name: 'feature/*',
-    channel: 'channel-${name}',
-    prerelease: "prerelease-${name.split('/').join('-')}"
+    channel: 'feature',
+    prerelease: "${name.split('/').slice(1).join('-').toLowerCase()}"
   }],
   tagFormat: 'v${version}',
   repositoryUrl: 'https://github.com/mParticle/aquarium',


### PR DESCRIPTION
## Summary

- With the decision to use trunk based development, the `dev` branch doesn't make much sense anymore. This PR removes it and makes it so that it's possible to publish versions from feature branches.

We still need to investigate edge cases but we need this merged on `main` to do it.

## Testing Plan

- [X] Was this tested locally? If not, explain why.
- Running `npx semantic-release --dry-run`  is generating the following version: `1.10.1-release-process.1`.
- [Release works](https://github.com/mParticle/aquarium/actions/runs/8485401033/job/23250104110)
- [NPM version](https://www.npmjs.com/package/@mparticle/aquarium/v/1.11.0-release-process.1)

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- Closes https://go.mparticle.com/work/UNI-264
