### PR TITLE
fix: remove "@supports selector()" from css

### DIFF
--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -34,21 +34,19 @@
 }
 
 /* Otherwise, use `::-webkit-scrollbar-*` pseudo-elements */
-@supports selector(::-webkit-scrollbar) {
-  .globalNavigation::-webkit-scrollbar {
-    /* stylelint-disable-next-line property-no-vendor-prefix */
-    -webkit-appearance: none;
-    width: var(--size-scrollbar-handle);
-    height: var(--size-scrollbar-handle);
-  }
+.globalNavigation::-webkit-scrollbar {
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-appearance: none;
+  width: var(--size-scrollbar-handle);
+  height: var(--size-scrollbar-handle);
+}
 
-  .globalNavigation::-webkit-scrollbar-track {
-    background-color: var(--color-scrollbar-track);
-  }
+.globalNavigation::-webkit-scrollbar-track {
+  background-color: var(--color-scrollbar-track);
+}
 
-  .globalNavigation::-webkit-scrollbar-thumb {
-    background-color: var(--color-scrollbar-handle);
-  }
+.globalNavigation::-webkit-scrollbar-thumb {
+  background-color: var(--color-scrollbar-handle);
 }
 
 .globalNavigation__sider {


### PR DESCRIPTION
## Summary

- While updating the Cortex to the latest version of the package, the build was failing. After some investigation, the issue was found with `@supports selector()` syntax that was used for the global nav styling. postcss-loader package in Cortex is outdated and probably does not know how to process this syntax. Updating packages in Cortex is complex and requires some time. As an easy fix, removing the query is more suitable, since it keeps the same logic in place and should resolve the compilation errors.

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- Run global navigation stories. Confirm the scroll bar is using an updated style.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
