### PR TITLE
fix: fixes path to be / on UPS cookie creation options

### DIFF
--- a/src/services/user-preferences/user-preferences.ts
+++ b/src/services/user-preferences/user-preferences.ts
@@ -75,6 +75,7 @@ export class UserPreferencesService<TUserPreferenceId extends PropertyKey> {
   private async setStoredPreferences(storedPreferences: UserPreferences<TUserPreferenceId>): Promise<void> {
     Cookies.putObject(this.cookieKey, storedPreferences, {
       expires: this.dateFormatter(),
+      path: '/',
     })
 
     await Promise.resolve()


### PR DESCRIPTION
## Summary
- Current cookie creation used in the UPS doesn't set the `path` option which causes the cookie to use the last but one path from the URL. This causes problems when using the UPS in the platforms.

More information in [this Nancy PR](https://git.corp.mparticle.com/mParticle/mPServer/pull/28254)

## Testing Plan
- [ ] Was this tested locally? If not, explain why.
- This was tested by fixing it in Nancy's codebase which still had the UPS code.
