### PR TITLE
fix: Align button content to the center

### DIFF
--- a/src/components/general/Button/Button.stories.tsx
+++ b/src/components/general/Button/Button.stories.tsx
@@ -112,6 +112,13 @@ export const WithIcon: Story = {
   },
 }
 
+export const WithIconSM: Story = {
+  args: {
+    type: 'default',
+    icon: <Icon name="mpLogo" size="sm" />,
+  },
+}
+
 export const Loading: Story = {
   args: {
     loading: true,

--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -1,13 +1,16 @@
 import { Button as AntButton } from 'antd'
 import { type ButtonProps as AntButtonProps } from 'antd'
 import { ConfigProvider } from 'src/components/other/ConfigProvider/ConfigProvider'
+import './button.css'
 
 export interface IButtonProps extends AntButtonProps {}
 
 export const Button = (props: IButtonProps) => {
   return (
     <ConfigProvider>
-      <AntButton {...props}>{props.children}</AntButton>
+      <AntButton {...props} className="button">
+        {props.children}
+      </AntButton>
     </ConfigProvider>
   )
 }

--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -8,7 +8,7 @@ export interface IButtonProps extends AntButtonProps {}
 export const Button = (props: IButtonProps) => {
   return (
     <ConfigProvider>
-      <AntButton {...props} className="aquarium-button">
+      <AntButton {...props} className={props.icon ? 'aquarium-button--aligned-center' : ''}>
         {props.children}
       </AntButton>
     </ConfigProvider>

--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -8,7 +8,7 @@ export interface IButtonProps extends AntButtonProps {}
 export const Button = (props: IButtonProps) => {
   return (
     <ConfigProvider>
-      <AntButton {...props} className="button">
+      <AntButton {...props} className="aquarium-button">
         {props.children}
       </AntButton>
     </ConfigProvider>

--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -1,14 +1,13 @@
 import { Button as AntButton } from 'antd'
 import { type ButtonProps as AntButtonProps } from 'antd'
 import { ConfigProvider } from 'src/components/other/ConfigProvider/ConfigProvider'
-import './button.css'
 
 export interface IButtonProps extends AntButtonProps {}
 
 export const Button = (props: IButtonProps) => {
   return (
     <ConfigProvider>
-      <AntButton {...props} className={props.icon ? 'aquarium-button--aligned-center' : ''}>
+      <AntButton {...props} className={props.icon ? 'u-display-flex u-align-items-center ' : ''}>
         {props.children}
       </AntButton>
     </ConfigProvider>

--- a/src/components/general/Button/button.css
+++ b/src/components/general/Button/button.css
@@ -1,0 +1,4 @@
+.button {
+    display: flex;
+    align-items: center;
+}

--- a/src/components/general/Button/button.css
+++ b/src/components/general/Button/button.css
@@ -1,4 +1,4 @@
-.button {
+.aquarium-button {
     display: flex;
     align-items: center;
 }

--- a/src/components/general/Button/button.css
+++ b/src/components/general/Button/button.css
@@ -1,4 +1,4 @@
-.aquarium-button {
+.aquarium-button--aligned-center {
     display: flex;
     align-items: center;
 }

--- a/src/components/general/Button/button.css
+++ b/src/components/general/Button/button.css
@@ -1,4 +1,0 @@
-.aquarium-button--aligned-center {
-    display: flex;
-    align-items: center;
-}

--- a/src/utils/utils.css
+++ b/src/utils/utils.css
@@ -1,3 +1,11 @@
 .u-display-none {
   display: none !important;
 }
+
+.u-display-flex {
+  display: flex;
+}
+
+.u-align-items-center{
+  align-items: center;
+}

--- a/src/utils/utils.css
+++ b/src/utils/utils.css
@@ -6,6 +6,6 @@
   display: flex !important;
 }
 
-.u-align-items-center{
+.u-align-items-center {
   align-items: center !important;
 }

--- a/src/utils/utils.css
+++ b/src/utils/utils.css
@@ -3,9 +3,9 @@
 }
 
 .u-display-flex {
-  display: flex;
+  display: flex !important;
 }
 
 .u-align-items-center{
-  align-items: center;
+  align-items: center !important;
 }


### PR DESCRIPTION
## Whenever a button has an icon larger than the label's font size, it becomes misaligned

![image](https://github.com/mParticle/aquarium/assets/17934324/6cef2ae5-301b-43e9-a87c-49e19cc5ecb9)

Currently, we are adding an icon through the icon prop. While version 5.17 (we are currently in 5.13) introduces iconPosition this prop only allows switching the icon between the left and right sides, not centering it.

<img width="126" alt="Screenshot 2024-05-23 at 9 24 08 PM" src="https://github.com/mParticle/aquarium/assets/17934324/96ef097f-48a4-4e34-af0b-12f55e9de00e">

<img width="131" alt="Screenshot 2024-05-23 at 9 24 21 PM" src="https://github.com/mParticle/aquarium/assets/17934324/5bcc18e0-8968-4930-ab4d-6a6b92716ab4">



Since we are adding it though props and not in the children, we can't use a Flex container to make the button aligned, and we can't let the children handle the alignment either. Here is a code snippet from ant's implementation on the icon/children. The rest of the code you can find it [here](https://github.com/ant-design/ant-design/blob/master/components/button/button.tsx#L261):

  ```
const genButtonContent = (iconComponent: React.ReactNode, kidsComponent: React.ReactNode) =>
    iconPosition === 'start' ? (
      <>
        {iconComponent}
        {kidsComponent}
      </>
    ) : (
      <>
        {kidsComponent}
        {iconComponent}
      </>
    );

```

As a workaround for this problem, I set up a class that makes the button flex and center aligned only when it has an icon

The button with the fix: 
<img width="439" alt="Screenshot 2024-05-23 at 4 26 06 PM" src="https://github.com/mParticle/aquarium/assets/17934324/072b9475-bdc7-4549-8baa-114505469e2d">
