### PR TITLE
feat: Add size prop to `Typography.Text` component

### DIFF
--- a/src/components/general/Typography/Text.stories.tsx
+++ b/src/components/general/Typography/Text.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof Typography.Text> = {
 
   args: {
     code: false,
+    size: 'base',
     copyable: false,
     delete: false,
     disabled: false,
@@ -32,6 +33,10 @@ const meta: Meta<typeof Typography.Text> = {
     type: {
       control: 'select',
       options: ['secondary', 'success', 'warning', 'danger'],
+    },
+    size: {
+      control: 'select',
+      options: ['base', 'sm', 'lg', 'xl'],
     },
   },
 }

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -25,6 +25,8 @@ export interface ITextProps extends AntTextProps {
   size?: TypographySize
 }
 
+// TODO: Replace hardcoded values in getFontSize and getLineHeight with tokens when design is ready
+// These values are currently coming from https://www.figma.com/design/LffDbOUjeYqDMZ3djs9Cga/mParticle-Foundation-v1.0.1?node-id=3745-8164&m=dev
 const getFontSize = (size: TypographySize): number => {
   if (size === 'base') return 14
   if (size === 'sm') return 12

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -1,10 +1,18 @@
-import { Typography as AntTypography, type TypographyProps as AntTypographyProps } from 'antd'
+import {
+  Typography as AntTypography,
+  type TypographyProps as AntTypographyProps,
+  theme,
+  ConfigProvider as AntConfigProvider,
+} from 'antd'
 import { ConfigProvider } from 'src/components'
 import { type ReactNode } from 'react'
 import { type TextProps as AntTextProps } from 'antd/es/typography/Text'
 import { type TitleProps as AntTitleProps } from 'antd/es/typography/Title'
 import { type LinkProps as AntLinkProps } from 'antd/es/typography/Link'
 import { type ParagraphProps as AntParagraphProps } from 'antd/es/typography/Paragraph'
+import type { FontMapToken } from 'antd/es/theme/interface'
+
+const { useToken } = theme
 
 export interface ITypographyProps extends AntTypographyProps {
   children: ReactNode
@@ -21,25 +29,33 @@ export interface ITextProps extends AntTextProps {
   size?: TypographySize
 }
 
-const getFontSizeVariable = (size: TypographySize): string => `--font-size${size === 'base' ? '' : `-${size}`}`
+type FontSizeToken = keyof Pick<FontMapToken, 'fontSize' | 'fontSizeSM' | 'fontSizeLG' | 'fontSizeXL'>
+type LineHeightToken = keyof Pick<FontMapToken, 'lineHeight' | 'lineHeightSM' | 'lineHeightLG'>
 
-const getLineHeightVariable = (size: TypographySize): string => {
-  if (size === 'sm') return `--line-height-sm`
-  if (size === 'lg' || size === 'xl') return '--line-height-lg'
-  return `--line-height`
+const getFontSizeToken = (size: TypographySize): FontSizeToken => {
+  if (size === 'base') return 'fontSize'
+  if (size === 'sm') return 'fontSizeSM'
+  if (size === 'lg') return 'fontSizeLG'
+  return 'fontSizeXL'
+}
+
+const getLineHeightToken = (size: TypographySize): LineHeightToken => {
+  if (size === 'base') return 'lineHeight'
+  if (size === 'sm') return 'lineHeightSM'
+  return 'lineHeightLG'
 }
 
 const Text = ({ size = 'base', ...props }: ITextProps) => {
+  const { token } = useToken()
+
+  const fontSize = token[getFontSizeToken(size)]
+  const lineHeight = token[getLineHeightToken(size)]
+
   return (
     <ConfigProvider>
-      <AntTypography.Text
-        style={{
-          fontSize: `var(${getFontSizeVariable(size)})`,
-          lineHeight: `var(${getLineHeightVariable(size)})`,
-        }}
-        {...props}>
-        {props.children}
-      </AntTypography.Text>
+      <AntConfigProvider theme={{ components: { Typography: { fontSize, lineHeight } } }}>
+        <AntTypography.Text {...props}>{props.children}</AntTypography.Text>
+      </AntConfigProvider>
     </ConfigProvider>
   )
 }

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -1,7 +1,6 @@
 import {
   Typography as AntTypography,
   type TypographyProps as AntTypographyProps,
-  theme,
   ConfigProvider as AntConfigProvider,
 } from 'antd'
 import { ConfigProvider } from 'src/components'
@@ -10,9 +9,6 @@ import { type TextProps as AntTextProps } from 'antd/es/typography/Text'
 import { type TitleProps as AntTitleProps } from 'antd/es/typography/Title'
 import { type LinkProps as AntLinkProps } from 'antd/es/typography/Link'
 import { type ParagraphProps as AntParagraphProps } from 'antd/es/typography/Paragraph'
-import type { FontMapToken } from 'antd/es/theme/interface'
-
-const { useToken } = theme
 
 export interface ITypographyProps extends AntTypographyProps {
   children: ReactNode
@@ -29,27 +25,23 @@ export interface ITextProps extends AntTextProps {
   size?: TypographySize
 }
 
-type FontSizeToken = keyof Pick<FontMapToken, 'fontSize' | 'fontSizeSM' | 'fontSizeLG' | 'fontSizeXL'>
-type LineHeightToken = keyof Pick<FontMapToken, 'lineHeight' | 'lineHeightSM' | 'lineHeightLG'>
-
-const getFontSizeToken = (size: TypographySize): FontSizeToken => {
-  if (size === 'base') return 'fontSize'
-  if (size === 'sm') return 'fontSizeSM'
-  if (size === 'lg') return 'fontSizeLG'
-  return 'fontSizeXL'
+const getFontSize = (size: TypographySize): number => {
+  if (size === 'base') return 14
+  if (size === 'sm') return 12
+  if (size === 'lg') return 16
+  return 20
 }
 
-const getLineHeightToken = (size: TypographySize): LineHeightToken => {
-  if (size === 'base') return 'lineHeight'
-  if (size === 'sm') return 'lineHeightSM'
-  return 'lineHeightLG'
+const getLineHeight = (size: TypographySize): number => {
+  if (size === 'base') return 1.571428571428571
+  if (size === 'sm') return 1.666666666666667
+  if (size === 'lg') return 1.5
+  return 1.4
 }
 
 const Text = ({ size = 'base', ...props }: ITextProps) => {
-  const { token } = useToken()
-
-  const fontSize = token[getFontSizeToken(size)]
-  const lineHeight = token[getLineHeightToken(size)]
+  const fontSize = getFontSize(size)
+  const lineHeight = getLineHeight(size)
 
   return (
     <ConfigProvider>

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -16,13 +16,34 @@ export const Typography = (props: ITypographyProps) => (
   </ConfigProvider>
 )
 
-export interface ITextProps extends AntTextProps {}
+type TypographySize = 'base' | 'sm' | 'lg' | 'xl'
+export interface ITextProps extends AntTextProps {
+  size?: TypographySize
+}
 
-const Text = (props: ITextProps) => (
-  <ConfigProvider>
-    <AntTypography.Text {...props}>{props.children}</AntTypography.Text>
-  </ConfigProvider>
-)
+const getFontSizeVariable = (size: TypographySize): string => `--font-size${size === 'base' ? '' : `-${size}`}`
+
+const getLineHeightVariable = (size: TypographySize): string => {
+  if (size === 'sm') return `--line-height-sm`
+  if (size === 'lg' || size === 'xl') return '--line-height-lg'
+  return `--line-height`
+}
+
+const Text = ({ size = 'base', ...props }: ITextProps) => {
+  return (
+    <ConfigProvider>
+      <AntTypography.Text
+        style={{
+          fontSize: `var(${getFontSizeVariable(size)})`,
+          lineHeight: `var(${getLineHeightVariable(size)})`,
+        }}
+        {...props}>
+        {props.children}
+      </AntTypography.Text>
+    </ConfigProvider>
+  )
+}
+
 Typography.Text = Text
 
 interface ITitleProps extends AntTitleProps {


### PR DESCRIPTION
## Instructions

1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary

- [EAMES](https://www.figma.com/design/LffDbOUjeYqDMZ3djs9Cga/mParticle-Foundation-v1.0.1?node-id=3745-8164&m=dev) specifies a size for a `Text` component. 

<img width="243" alt="Screenshot 2024-06-04 at 8 15 36 AM" src="https://github.com/mParticle/aquarium/assets/169929453/4579cff5-cea4-437e-ac0e-5611b0405048">


## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Tested in storybook, using a control. Default behaviour (`base`) is preserved so it's backwards compat.



## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
