### PR TITLE
fix: hide minimap after user clicks on a button

### DIFF
--- a/src/components/navigation/GlobalNavigation/HomeButton.tsx
+++ b/src/components/navigation/GlobalNavigation/HomeButton.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Center, Icon, Popover, Tooltip } from 'src/components'
 import MiniMap from 'src/components/navigation/MiniMap/MiniMap'
-import { IMiniMapOptions } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
+import { IMiniMapOptions, MiniMapLink } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
 
 interface MpHomeButtonProps {
   onClick: () => void
@@ -29,18 +29,29 @@ function MpHomeButton(props: MpHomeButtonProps) {
 }
 
 function MinimapWithPopover(props: MinimapWithPopoverProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+  const handleLinkClick = (link: MiniMapLink) => {
+    setIsPopoverOpen(false)
+    props.onLinkClick(link)
+  }
+  const handlePopoverOpenChange = (newPopoverState: boolean) => {
+    setIsPopoverOpen(newPopoverState)
+  }
+
   return (
     <Popover
-      content={() => (
+      content={
         <MiniMap
           overviewHref={props.overviewHref}
           onUnauthorizedClick={props.onUnauthorizedClick}
           links={props.links}
-          onLinkClick={props.onLinkClick}
+          onLinkClick={handleLinkClick}
           unauthorizedLinks={props.unauthorizedLinks}
         />
-      )}
+      }
       placement="rightBottom"
+      open={isPopoverOpen}
+      onOpenChange={handlePopoverOpenChange}
       arrow={false}>
       <MpHomeButton onClick={props.onPopoverClick} />
     </Popover>


### PR DESCRIPTION
## Instructions

## Summary

This PR ensures that the popover is closed when the user clicks on a link inside the svg

[Component live:](https://65aec861fa4adbf0708aebd0-tmzgajeyji.chromatic.com/?path=/story/aquarium-navigation-globalnavigation--mp )

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/UNI-654
