### PR TITLE
chore: dont allow wrapping of query item text component

### DIFF
--- a/src/components/data-entry/QueryItem/Text.tsx
+++ b/src/components/data-entry/QueryItem/Text.tsx
@@ -7,7 +7,7 @@ export interface ITextProps {
 
 export const Text = ({ disabled = false, text }: ITextProps) => {
   return (
-    <Typography.Text disabled={disabled} style={{ textWrap: 'nowrap' }}>
+    <Typography.Text disabled={disabled} style={{ whiteSpace: 'nowrap' }}>
       {text}
     </Typography.Text>
   )

--- a/src/components/data-entry/QueryItem/Text.tsx
+++ b/src/components/data-entry/QueryItem/Text.tsx
@@ -6,7 +6,11 @@ export interface ITextProps {
 }
 
 export const Text = ({ disabled = false, text }: ITextProps) => {
-  return <Typography.Text disabled={disabled}>{text}</Typography.Text>;
+  return (
+    <Typography.Text disabled={disabled} style={{ textWrap: 'nowrap' }}>
+      {text}
+    </Typography.Text>
+  )
 }
 
 export default Text

--- a/src/components/data-entry/QueryItem/TextInput.tsx
+++ b/src/components/data-entry/QueryItem/TextInput.tsx
@@ -29,7 +29,8 @@ export const TextInput = (props: ITextInputProps) => {
         className={inputClasses}
         value={props.value}
         placeholder={props.placeholder}
-        onChange={_onChange}></Input>
+        onChange={_onChange}
+      />
       {props.errorMessage && <Typography.Text type="danger">{props.errorMessage}</Typography.Text>}
     </>
   )

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -16,8 +16,7 @@ export const Typography = (props: ITypographyProps) => (
   </ConfigProvider>
 )
 
-export interface ITextProps extends AntTextProps {
-}
+export interface ITextProps extends AntTextProps {}
 
 const Text = (props: ITextProps) => (
   <ConfigProvider>


### PR DESCRIPTION
## Instructions
1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary
- the typography component from the aquarium has `word-break: break-word;`, which causes the component to wrap (see screenshot)
this can be turned off by adding [white-space](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space): nowrap

## Screenshots
<img width="469" alt="image" src="https://github.com/mParticle/aquarium/assets/14081357/e2f8a922-498e-466d-b7c0-42719626aca6">
