### PR TITLE
feat: Add withConfigProvider to facilitate removal of wrapping every single component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -74,7 +74,7 @@ export {
   type MenuDividerType,
   type IMenuInfo,
 } from './navigation/Menu/Menu'
-export { ConfigProvider, type IConfigProviderProps } from './other/ConfigProvider/ConfigProvider'
+export { ConfigProvider, withConfigProvider, type IConfigProviderProps } from './other/ConfigProvider/ConfigProvider'
 export { Affix, type IAffixProps } from './other/Affix/Affix'
 export { App, type IAppProps } from './other/App/App'
 export {

--- a/src/components/other/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/other/ConfigProvider/ConfigProvider.tsx
@@ -8,6 +8,15 @@ export const ConfigProvider = (props: IConfigProviderProps) => {
   return <AntConfigProvider {...props} theme={LightTheme} />
 }
 
+export const withConfigProvider =
+  <P extends object>(Component: React.ComponentType<P>) =>
+  // eslint-disable-next-line react/display-name
+  (props: P) => (
+    <ConfigProvider>
+      <Component {...props} />
+    </ConfigProvider>
+  )
+
 ConfigProvider.ConfigContext = AntConfigProvider.ConfigContext
 ConfigProvider.useConfig = AntConfigProvider.useConfig
 ConfigProvider.config = AntConfigProvider.config


### PR DESCRIPTION
## Instructions

1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary

Nearly all components currently in the aquarium (not all, just most) follow the same pattern of wrapping antd without modification, and exporting to consumers. The one functionality that is provided, however, is wrapping every individual antd component in Antd's `ConfigProvider` with mParticle's theme.

We would not have to wrap antd components and re-export them wrapped in an mParticle `ConfigProvider` if the consumer had a `ConfigProvider` at it's root where the consumed component was being rendered. 

This initial PR will have several follow up PRs in consuming applications and also in aquarium. Namely to:

1. Create a global storybook decorator that wraps all our stories
2. Use the `withConfigProvider` in various consuming UIs to provide a root mParticle ConfigProvider whereever an aquairum component is used
3. Delete all "wrapped but not extended" components and stories and replace them with direct antd exports (this may require updating type annotations in consuming applications to facilitate them upgrading. Basically, we'd no longer have to do things like this: https://github.com/mParticle/aquarium/pull/282, we'd get all of antd for free in consuming applications.

Technically, `withConfigProvider` isn't even needed at all, consuming applications can just use `<ConfigProvider>` at the root of their react tree. It's (arguably) a nice helper utility though to facilitate the removal of the responsibility of every single component to be wrapped and helps start the conversation


## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
