### PR TITLE
fix: button-alligned center

### DIFF
--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -12,7 +12,7 @@ export interface IButtonProps extends AntButtonProps {
 }
 export const Button = (props: IButtonProps) => {
   const classMap = {
-    'with-new-icon': 'u-display-flex u-align-items-center',
+    'with-new-icon': 'u-display-flex u-align-items-center u-justify-center',
   }
 
   return (

--- a/src/utils/utils.css
+++ b/src/utils/utils.css
@@ -10,6 +10,10 @@
   align-items: center !important;
 }
 
+.u-justify-center {
+  justify-content: center !important;
+}
+
 .u-padding-sm {
   padding:var(--padding-sm) !important;
 }


### PR DESCRIPTION
this fix solves the issue that when no text, the icon is not aligned