### PR TITLE
chore: add configprovider decorator 🔴 DO NOT MERGE - BREAKING 🔴 

### DIFF
--- a/.storybook/decorators/MPConfigProvider.tsx
+++ b/.storybook/decorators/MPConfigProvider.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { Decorator } from '@storybook/react'
+import { ConfigProvider } from '../../src/components/other/ConfigProvider/ConfigProvider'
+
+export const MPConfigProviderDecorator: Decorator = Story => (
+  <ConfigProvider>
+    <Story />
+  </ConfigProvider>
+)

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,8 @@
 import type { Preview } from '@storybook/react'
+import { MPConfigProviderDecorator } from './decorators/MPConfigProvider'
 
 const preview: Preview = {
+  decorators: [MPConfigProviderDecorator],
   parameters: {
     layout: 'centered',
 

--- a/src/components/data-display/Avatar/Avatar.tsx
+++ b/src/components/data-display/Avatar/Avatar.tsx
@@ -1,15 +1,10 @@
 import { Avatar as AntAvatar } from 'antd'
 import { type AvatarProps as AntAvatarProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IAvatarProps extends AntAvatarProps {}
 
 export const Avatar = (props: IAvatarProps) => {
-  return (
-    <ConfigProvider>
-      <AntAvatar {...props} />
-    </ConfigProvider>
-  )
+  return <AntAvatar {...props} />
 }
 
 Avatar.Group = AntAvatar.Group

--- a/src/components/data-display/Badge/Badge.tsx
+++ b/src/components/data-display/Badge/Badge.tsx
@@ -1,15 +1,10 @@
 import { Badge as AntBadge } from 'antd'
 import { type BadgeProps as AntBadgeProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IBadgeProps extends AntBadgeProps {}
 
 export const Badge = (props: IBadgeProps) => {
-  return (
-    <ConfigProvider>
-      <AntBadge {...props} />
-    </ConfigProvider>
-  )
+  return <AntBadge {...props} />
 }
 
 Badge.Ribbon = AntBadge.Ribbon

--- a/src/components/data-display/Calendar/Calendar.tsx
+++ b/src/components/data-display/Calendar/Calendar.tsx
@@ -1,15 +1,10 @@
 import { Calendar as AntCalendar, type CalendarProps as AntCalendarProps } from 'antd'
 import { type Dayjs } from 'dayjs'
-import { ConfigProvider } from 'src/components'
 
 export interface ICalendarProps extends AntCalendarProps<Dayjs> {}
 
 export const Calendar = (props: ICalendarProps) => {
-  return (
-    <ConfigProvider>
-      <AntCalendar {...props} />
-    </ConfigProvider>
-  )
+  return <AntCalendar {...props} />
 }
 
 Calendar.generateCalendar = AntCalendar.generateCalendar

--- a/src/components/data-display/Card/Card.tsx
+++ b/src/components/data-display/Card/Card.tsx
@@ -1,15 +1,11 @@
 import { Card as AntCard } from 'antd'
 import { type CardProps as AntCardProps } from 'antd'
-import { ConfigProvider } from 'src/components/other/ConfigProvider/ConfigProvider'
+
 
 export interface ICardProps extends AntCardProps {}
 
 export const Card = (props: ICardProps) => {
-  return (
-    <ConfigProvider>
-      <AntCard {...props} />
-    </ConfigProvider>
-  )
+  return <AntCard {...props} />
 }
 
 Card.Meta = AntCard.Meta

--- a/src/components/data-display/Carousel/Carousel.tsx
+++ b/src/components/data-display/Carousel/Carousel.tsx
@@ -1,13 +1,8 @@
 import { Carousel as AntCarousel } from 'antd'
 import { type CarouselProps as AntCarouselProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ICarouselProps extends AntCarouselProps {}
 
 export const Carousel = (props: ICarouselProps) => {
-  return (
-    <ConfigProvider>
-      <AntCarousel {...props} />
-    </ConfigProvider>
-  )
+  return <AntCarousel {...props} />
 }

--- a/src/components/data-display/Collapse/Collapse.tsx
+++ b/src/components/data-display/Collapse/Collapse.tsx
@@ -1,15 +1,10 @@
 import { Collapse as AntCollapse } from 'antd'
 import { type CollapseProps as AntCollapseProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ICollapseProps extends AntCollapseProps {}
 
 export const Collapse = (props: ICollapseProps) => {
-  return (
-    <ConfigProvider>
-      <AntCollapse {...props} />
-    </ConfigProvider>
-  )
+  return <AntCollapse {...props} />
 }
 
 Collapse.Panel = AntCollapse.Panel

--- a/src/components/data-display/Descriptions/Descriptions.tsx
+++ b/src/components/data-display/Descriptions/Descriptions.tsx
@@ -1,15 +1,10 @@
 import { Descriptions as AntDescriptions } from 'antd'
 import { type DescriptionsProps as AntDescriptionsProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IDescriptionsProps extends AntDescriptionsProps {}
 
 export const Descriptions = (props: IDescriptionsProps) => {
-  return (
-    <ConfigProvider>
-      <AntDescriptions {...props} />
-    </ConfigProvider>
-  )
+  return <AntDescriptions {...props} />
 }
 
 Descriptions.Item = AntDescriptions.Item

--- a/src/components/data-display/Empty/Empty.tsx
+++ b/src/components/data-display/Empty/Empty.tsx
@@ -1,15 +1,11 @@
 import { Empty as AntEmpty } from 'antd'
 import { type EmptyProps as AntEmptyProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface IEmptyProps extends AntEmptyProps {}
 
 export const Empty = (props: IEmptyProps) => {
-  return (
-    <ConfigProvider>
-      <AntEmpty {...props} />
-    </ConfigProvider>
-  )
+  return <AntEmpty {...props} />
 }
 
 Empty.PRESENTED_IMAGE_DEFAULT = AntEmpty.PRESENTED_IMAGE_DEFAULT

--- a/src/components/data-display/Image/Image.tsx
+++ b/src/components/data-display/Image/Image.tsx
@@ -1,15 +1,10 @@
 import { Image as AntImage } from 'antd'
 import { type ImageProps as AntImageProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IImageProps extends AntImageProps {}
 
 export const Image = (props: IImageProps) => {
-  return (
-    <ConfigProvider>
-      <AntImage {...props} />
-    </ConfigProvider>
-  )
+  return <AntImage {...props} />
 }
 
 Image.PreviewGroup = AntImage.PreviewGroup

--- a/src/components/data-display/List/List.tsx
+++ b/src/components/data-display/List/List.tsx
@@ -1,15 +1,10 @@
 import { List as AntList } from 'antd'
 import { type ListProps as AntListProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IListProps<T> extends AntListProps<T> {}
 
 export function List<T>(props: IListProps<T>) {
-  return (
-    <ConfigProvider>
-      <AntList {...props} />
-    </ConfigProvider>
-  )
+  return <AntList {...props} />
 }
 
 List.Item = AntList.Item

--- a/src/components/data-display/Popover/Popover.tsx
+++ b/src/components/data-display/Popover/Popover.tsx
@@ -1,17 +1,14 @@
 import { Popover as AntPopover } from 'antd'
 import { type PopoverProps as AntPopoverProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IPopoverProps extends AntPopoverProps {}
 
 export const Popover = (props: IPopoverProps) => {
   return (
-    <ConfigProvider>
-      <AntPopover {...props}>
-        {/* Fragment fixes popover sometimes not showing */}
-        {/* https://github.com/ant-design/ant-design/issues/15909 */}
-        <>{props.children}</>
-      </AntPopover>
-    </ConfigProvider>
+    <AntPopover {...props}>
+      {/* Fragment fixes popover sometimes not showing */}
+      {/* https://github.com/ant-design/ant-design/issues/15909 */}
+      <>{props.children}</>
+    </AntPopover>
   )
 }

--- a/src/components/data-display/QRCode/QRCode.tsx
+++ b/src/components/data-display/QRCode/QRCode.tsx
@@ -1,13 +1,9 @@
 import { QRCode as AntQRCode } from 'antd'
 import { type QRCodeProps as AntQRCodeProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface IQRCodeProps extends AntQRCodeProps {}
 
 export const QRCode = (props: IQRCodeProps) => {
-  return (
-    <ConfigProvider>
-      <AntQRCode {...props} />
-    </ConfigProvider>
-  )
+  return <AntQRCode {...props} />
 }

--- a/src/components/data-display/Segmented/Segmented.tsx
+++ b/src/components/data-display/Segmented/Segmented.tsx
@@ -1,15 +1,10 @@
 import { Segmented as AntSegmented } from 'antd'
 import { type SegmentedProps as AntSegmentedProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ISegmentedProps extends AntSegmentedProps {
   ref?: React.RefObject<HTMLDivElement>
 }
 
 export const Segmented = (props: ISegmentedProps) => {
-  return (
-    <ConfigProvider>
-      <AntSegmented {...props} />
-    </ConfigProvider>
-  )
+  return <AntSegmented {...props} />
 }

--- a/src/components/data-display/Statistic/Statistic.tsx
+++ b/src/components/data-display/Statistic/Statistic.tsx
@@ -2,18 +2,13 @@ import { Statistic as AntStatistic } from 'antd'
 import { type StatisticProps as AntStatisticProps } from 'antd'
 import { type CountdownProps as AntCountdownProps } from 'antd'
 import { type valueType as AntValueType } from 'antd/es/statistic/utils'
-import { ConfigProvider } from 'src/components'
 
 export interface IStatisticProps extends AntStatisticProps {}
 export interface ICountdownProps extends AntCountdownProps {}
 export type valueType = AntValueType
 
 export const Statistic = (props: IStatisticProps) => {
-  return (
-    <ConfigProvider>
-      <AntStatistic {...props} />
-    </ConfigProvider>
-  )
+  return <AntStatistic {...props} />
 }
 
 Statistic.Countdown = AntStatistic.Countdown

--- a/src/components/data-display/Table/Table.tsx
+++ b/src/components/data-display/Table/Table.tsx
@@ -1,7 +1,6 @@
 import { Table as AntTable } from 'antd'
 import { type TableProps as AntTableProps } from 'antd'
 import { type AnyObject } from 'antd/es/_util/type'
-import { ConfigProvider } from 'src/components'
 import { type ColumnType, type ExpandableConfig } from 'antd/es/table/interface'
 import { type ColumnsType, type TableProps } from 'antd/es/table'
 
@@ -10,11 +9,7 @@ export interface ITableProps<RecordType extends AnyObject = AnyObject> extends A
 export type { ColumnType, ExpandableConfig, ColumnsType, TableProps }
 
 export const Table = <RecordType extends AnyObject = AnyObject>(props: ITableProps<RecordType>) => {
-  return (
-    <ConfigProvider>
-      <AntTable<RecordType> {...props} />
-    </ConfigProvider>
-  )
+  return <AntTable<RecordType> {...props} />
 }
 
 Table.Column = AntTable.Column

--- a/src/components/data-display/Tabs/Tabs.tsx
+++ b/src/components/data-display/Tabs/Tabs.tsx
@@ -1,15 +1,10 @@
 import { Tabs as AntTabs } from 'antd'
 import { type TabsProps as AntTabsProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITabsProps extends AntTabsProps {}
 
 export const Tabs = (props: ITabsProps) => {
-  return (
-    <ConfigProvider>
-      <AntTabs {...props} />
-    </ConfigProvider>
-  )
+  return <AntTabs {...props} />
 }
 
 Tabs.TabPane = AntTabs.TabPane

--- a/src/components/data-display/Tag/Tag.tsx
+++ b/src/components/data-display/Tag/Tag.tsx
@@ -1,7 +1,6 @@
 import { Tag as AntTag } from 'antd'
 import { type TagProps as AntTagProps } from 'antd'
 import { type CheckableTagProps as AntCheckableTagProps } from 'antd/es/tag'
-import { ConfigProvider } from 'src/components'
 
 export interface ITagProps extends AntTagProps {
   children: React.ReactNode
@@ -10,19 +9,11 @@ export interface ITagProps extends AntTagProps {
 type CheckableTagProps = AntCheckableTagProps & ITagProps
 
 export const Tag = (props: ITagProps) => {
-  return (
-    <ConfigProvider>
-      <AntTag {...props} />
-    </ConfigProvider>
-  )
+  return <AntTag {...props} />
 }
 
 const CheckableTag = (props: CheckableTagProps) => {
-  return (
-    <ConfigProvider>
-      <AntTag.CheckableTag {...props} />
-    </ConfigProvider>
-  )
+  return <AntTag.CheckableTag {...props} />
 }
 
 Tag.CheckableTag = CheckableTag

--- a/src/components/data-display/Timeline/Timeline.tsx
+++ b/src/components/data-display/Timeline/Timeline.tsx
@@ -1,15 +1,11 @@
 import { Timeline as AntTimeline } from 'antd'
 import { type TimelineProps as AntTimelineProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface ITimelineProps extends AntTimelineProps {}
 
 export const Timeline = (props: ITimelineProps) => {
-  return (
-    <ConfigProvider>
-      <AntTimeline {...props} />
-    </ConfigProvider>
-  )
+  return <AntTimeline {...props} />
 }
 
 Timeline.Item = AntTimeline.Item

--- a/src/components/data-display/Tooltip/Tooltip.tsx
+++ b/src/components/data-display/Tooltip/Tooltip.tsx
@@ -1,17 +1,14 @@
 import { Tooltip as AntTooltip } from 'antd'
 import { type TooltipPropsWithTitle as AntTooltipPropsWithTitle } from 'antd/es/tooltip'
-import { ConfigProvider } from 'src/components'
 
 export interface ITooltipProps extends AntTooltipPropsWithTitle {}
 
 export const Tooltip = (props: ITooltipProps) => {
   return (
-    <ConfigProvider>
-      <AntTooltip {...props}>
-        {/* Fragment fixes tooltip sometimes not showing */}
-        {/* https://github.com/ant-design/ant-design/issues/15909 */}
-        <>{props.children}</>
-      </AntTooltip>
-    </ConfigProvider>
+    <AntTooltip {...props}>
+      {/* Fragment fixes tooltip sometimes not showing */}
+      {/* https://github.com/ant-design/ant-design/issues/15909 */}
+      <>{props.children}</>
+    </AntTooltip>
   )
 }

--- a/src/components/data-display/Tour/Tour.tsx
+++ b/src/components/data-display/Tour/Tour.tsx
@@ -1,13 +1,8 @@
 import { Tour as AntTour } from 'antd'
 import { type TourProps as AntTourProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITourProps extends AntTourProps {}
 
 export const Tour = (props: ITourProps) => {
-  return (
-    <ConfigProvider>
-      <AntTour {...props} />
-    </ConfigProvider>
-  )
+  return <AntTour {...props} />
 }

--- a/src/components/data-display/Tree/Tree.tsx
+++ b/src/components/data-display/Tree/Tree.tsx
@@ -1,17 +1,12 @@
 import { Tree as AntTree, type TreeDataNode } from 'antd'
 import { type TreeProps as AntTreeProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITreeProps extends AntTreeProps {}
 
 export interface ITreeData extends TreeDataNode {}
 
 export const Tree = (props: ITreeProps) => {
-  return (
-    <ConfigProvider>
-      <AntTree {...props} />
-    </ConfigProvider>
-  )
+  return <AntTree {...props} />
 }
 
 Tree.DirectoryTree = AntTree.DirectoryTree

--- a/src/components/data-entry/AutoComplete/AutoComplete.tsx
+++ b/src/components/data-entry/AutoComplete/AutoComplete.tsx
@@ -1,13 +1,8 @@
 import { AutoComplete as AntAutoComplete } from 'antd'
 import { type AutoCompleteProps as AntAutoCompleteProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IAutoCompleteProps extends AntAutoCompleteProps {}
 
 export const AutoComplete = (props: IAutoCompleteProps) => {
-  return (
-    <ConfigProvider>
-      <AntAutoComplete {...props} />
-    </ConfigProvider>
-  )
+  return <AntAutoComplete {...props} />
 }

--- a/src/components/data-entry/Cascader/Cascader.tsx
+++ b/src/components/data-entry/Cascader/Cascader.tsx
@@ -1,16 +1,11 @@
 import { Cascader as AntCascader } from 'antd'
 import { type CascaderProps as AntCascaderProps } from 'antd'
 import { type BaseOptionType } from 'antd/es/select'
-import { ConfigProvider } from 'src/components'
 
 export type ICascaderProps<DataNodeType extends BaseOptionType = any> = AntCascaderProps<DataNodeType>
 
 export const Cascader = (props: ICascaderProps) => {
-  return (
-    <ConfigProvider>
-      <AntCascader {...props} />
-    </ConfigProvider>
-  )
+  return <AntCascader {...props} />
 }
 
 Cascader.Panel = AntCascader.Panel

--- a/src/components/data-entry/Checkbox/Checkbox.tsx
+++ b/src/components/data-entry/Checkbox/Checkbox.tsx
@@ -1,15 +1,10 @@
 import { Checkbox as AntCheckbox } from 'antd'
 import { type CheckboxProps as AntCheckboxProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ICheckboxProps extends AntCheckboxProps {}
 
 export const Checkbox = (props: ICheckboxProps) => {
-  return (
-    <ConfigProvider>
-      <AntCheckbox {...props} />
-    </ConfigProvider>
-  )
+  return <AntCheckbox {...props} />
 }
 
 Checkbox.Group = AntCheckbox.Group

--- a/src/components/data-entry/ColorPicker/ColorPicker.tsx
+++ b/src/components/data-entry/ColorPicker/ColorPicker.tsx
@@ -1,13 +1,8 @@
 import { ColorPicker as AntColorPicker } from 'antd'
 import { type ColorPickerProps as AntColorPickerProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IColorPickerProps extends AntColorPickerProps {}
 
 export const ColorPicker = (props: IColorPickerProps) => {
-  return (
-    <ConfigProvider>
-      <AntColorPicker {...props} />
-    </ConfigProvider>
-  )
+  return <AntColorPicker {...props} />
 }

--- a/src/components/data-entry/DatePicker/DatePicker.tsx
+++ b/src/components/data-entry/DatePicker/DatePicker.tsx
@@ -1,14 +1,9 @@
 import { DatePicker as AntDatePicker, type DatePickerProps as AntDatePickerProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IDatePickerProps extends AntDatePickerProps {}
 
 export const DatePicker = (props: IDatePickerProps) => {
-  return (
-    <ConfigProvider>
-      <AntDatePicker {...props} />
-    </ConfigProvider>
-  )
+  return <AntDatePicker {...props} />
 }
 
 DatePicker.generatePicker = AntDatePicker.generatePicker

--- a/src/components/data-entry/Form/Form.tsx
+++ b/src/components/data-entry/Form/Form.tsx
@@ -1,6 +1,5 @@
 import { Form as AntForm } from 'antd'
 import { type FormProps as AntFormProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 import { type ReactNode } from 'react'
 
 export interface IFormProps extends AntFormProps {
@@ -8,11 +7,7 @@ export interface IFormProps extends AntFormProps {
 }
 
 export const Form = (props: IFormProps) => {
-  return (
-    <ConfigProvider>
-      <AntForm {...props}>{props.children}</AntForm>
-    </ConfigProvider>
-  )
+  return <AntForm {...props}>{props.children}</AntForm>
 }
 
 Form.useForm = AntForm.useForm

--- a/src/components/data-entry/Input/Input.tsx
+++ b/src/components/data-entry/Input/Input.tsx
@@ -1,7 +1,6 @@
 import { Input as AntInput } from 'antd'
 import { type InputProps as AntInputProps } from 'antd'
 import { type SearchProps } from 'antd/es/input'
-import { ConfigProvider } from 'src/components'
 import { type InputRef } from 'antd'
 import { forwardRef, type ForwardRefExoticComponent, type Ref, type RefAttributes } from 'react'
 
@@ -19,21 +18,13 @@ type CompoundedComponent = ForwardRefExoticComponent<IInputProps & RefAttributes
 }
 
 const InternalInput = (props: IInputProps, ref: Ref<InputRef>) => {
-  return (
-    <ConfigProvider>
-      <AntInput {...props} ref={ref} />
-    </ConfigProvider>
-  )
+  return <AntInput {...props} ref={ref} />
 }
 
 const InternalInputWithRef = forwardRef(InternalInput)
 const Input = InternalInputWithRef as CompoundedComponent
 
-const InternalSearch = (props: ISearchProps, ref: Ref<InputRef>) => (
-  <ConfigProvider>
-    <AntInput.Search ref={ref} {...props} />
-  </ConfigProvider>
-)
+const InternalSearch = (props: ISearchProps, ref: Ref<InputRef>) => <AntInput.Search ref={ref} {...props} />
 const InternalSearchWithRef = forwardRef(InternalSearch)
 const Search = InternalSearchWithRef as CompoundedComponent
 

--- a/src/components/data-entry/InputNumber/InputNumber.tsx
+++ b/src/components/data-entry/InputNumber/InputNumber.tsx
@@ -1,13 +1,8 @@
 import { InputNumber as AntInputNumber } from 'antd'
 import { type InputNumberProps as AntInputNumberProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IInputNumberProps extends AntInputNumberProps {}
 
 export const InputNumber = (props: IInputNumberProps) => {
-  return (
-    <ConfigProvider>
-      <AntInputNumber {...props} />
-    </ConfigProvider>
-  )
+  return <AntInputNumber {...props} />
 }

--- a/src/components/data-entry/Mentions/Mentions.tsx
+++ b/src/components/data-entry/Mentions/Mentions.tsx
@@ -1,15 +1,10 @@
 import { Mentions as AntMentions } from 'antd'
 import { type MentionProps as AntMentionProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IMentionsProps extends AntMentionProps {}
 
 export const Mentions = (props: IMentionsProps) => {
-  return (
-    <ConfigProvider>
-      <AntMentions {...props} />
-    </ConfigProvider>
-  )
+  return <AntMentions {...props} />
 }
 
 Mentions.getMentions = AntMentions.getMentions

--- a/src/components/data-entry/Radio/Radio.tsx
+++ b/src/components/data-entry/Radio/Radio.tsx
@@ -1,17 +1,12 @@
 import { Radio as AntRadio } from 'antd'
 import { type RadioProps as AntRadioProps } from 'antd'
-import { ConfigProvider } from 'src/components'
-import { RadioGroup } from "./RadioGroup";
-import { RadioButton } from "./RadioButton";
+import { RadioGroup } from './RadioGroup'
+import { RadioButton } from './RadioButton'
 
 export interface IRadioProps extends AntRadioProps {}
 
 export const Radio = (props: IRadioProps) => {
-  return (
-    <ConfigProvider>
-      <AntRadio {...props} />
-    </ConfigProvider>
-  )
+  return <AntRadio {...props} />
 }
 
 // TODO Is there a way to type the props from Radio.Group better so that value types are inferred?

--- a/src/components/data-entry/Radio/RadioButton.tsx
+++ b/src/components/data-entry/Radio/RadioButton.tsx
@@ -1,13 +1,8 @@
 import { Radio as AntRadio } from 'antd'
-import { type RadioButtonProps as AntRadioGroupProps } from "antd/es/radio/radioButton";
-import { ConfigProvider } from 'src/components'
+import { type RadioButtonProps as AntRadioGroupProps } from 'antd/es/radio/radioButton'
 
 export interface IRadioButtonProps extends AntRadioGroupProps {}
 
 export const RadioButton = (props: IRadioButtonProps) => {
-  return (
-    <ConfigProvider>
-      <AntRadio.Button {...props} />
-    </ConfigProvider>
-  )
+  return <AntRadio.Button {...props} />
 }

--- a/src/components/data-entry/Radio/RadioGroup.tsx
+++ b/src/components/data-entry/Radio/RadioGroup.tsx
@@ -1,13 +1,8 @@
 import { Radio as AntRadio } from 'antd'
 import { type RadioGroupProps as AntRadioGroupProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IRadioGroupProps extends AntRadioGroupProps {}
 
 export const RadioGroup = (props: IRadioGroupProps) => {
-  return (
-    <ConfigProvider>
-      <AntRadio.Group {...props} />
-    </ConfigProvider>
-  )
+  return <AntRadio.Group {...props} />
 }

--- a/src/components/data-entry/Rate/Rate.tsx
+++ b/src/components/data-entry/Rate/Rate.tsx
@@ -1,13 +1,8 @@
 import { Rate as AntRate } from 'antd'
 import { type RateProps as AntRateProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IRateProps extends AntRateProps {}
 
 export const Rate = (props: IRateProps) => {
-  return (
-    <ConfigProvider>
-      <AntRate {...props} />
-    </ConfigProvider>
-  )
+  return <AntRate {...props} />
 }

--- a/src/components/data-entry/Select/Select.tsx
+++ b/src/components/data-entry/Select/Select.tsx
@@ -1,7 +1,6 @@
 import { Select as AntSelect } from 'antd'
 import { type SelectProps as AntSelectProps } from 'antd'
 import { type BaseOptionType, type DefaultOptionType } from 'antd/es/select'
-import { ConfigProvider } from 'src/components'
 
 export interface ISelectProps<
   ValueType = any,
@@ -9,11 +8,7 @@ export interface ISelectProps<
 > extends AntSelectProps<ValueType, OptionType> {}
 
 export const Select = (props: ISelectProps) => {
-  return (
-    <ConfigProvider>
-      <AntSelect {...props} />
-    </ConfigProvider>
-  )
+  return <AntSelect {...props} />
 }
 
 Select.Option = AntSelect.Option

--- a/src/components/data-entry/Slider/Slider.tsx
+++ b/src/components/data-entry/Slider/Slider.tsx
@@ -1,14 +1,9 @@
 import { Slider as AntSlider } from 'antd'
 import { type SliderRangeProps } from 'antd/es/slider'
 import { type SliderSingleProps } from 'antd/es/slider'
-import { ConfigProvider } from 'src/components'
 
 export type ISliderProps = SliderSingleProps | SliderRangeProps
 
 export const Slider = (props: ISliderProps) => {
-  return (
-    <ConfigProvider>
-      <AntSlider {...props} />
-    </ConfigProvider>
-  )
+  return <AntSlider {...props} />
 }

--- a/src/components/data-entry/Switch/Switch.tsx
+++ b/src/components/data-entry/Switch/Switch.tsx
@@ -1,13 +1,8 @@
 import { Switch as AntSwitch } from 'antd'
 import { type SwitchProps as AntSwitchProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ISwitchProps extends AntSwitchProps {}
 
 export const Switch = (props: ISwitchProps) => {
-  return (
-    <ConfigProvider>
-      <AntSwitch {...props} />
-    </ConfigProvider>
-  )
+  return <AntSwitch {...props} />
 }

--- a/src/components/data-entry/TimePicker/TimePicker.tsx
+++ b/src/components/data-entry/TimePicker/TimePicker.tsx
@@ -1,15 +1,10 @@
 import { TimePicker as AntTimePicker } from 'antd'
 import { type TimePickerProps as AntTimePickerProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITimePickerProps extends AntTimePickerProps {}
 
 export const TimePicker = (props: ITimePickerProps) => {
-  return (
-    <ConfigProvider>
-      <AntTimePicker {...props} />
-    </ConfigProvider>
-  )
+  return <AntTimePicker {...props} />
 }
 
 TimePicker.RangePicker = AntTimePicker.RangePicker

--- a/src/components/data-entry/Transfer/Transfer.tsx
+++ b/src/components/data-entry/Transfer/Transfer.tsx
@@ -1,15 +1,10 @@
 import { Transfer as AntTransfer } from 'antd'
 import { type TransferProps as AntTransferProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITransferProps extends AntTransferProps {}
 
 export const Transfer = (props: ITransferProps) => {
-  return (
-    <ConfigProvider>
-      <AntTransfer {...props} />
-    </ConfigProvider>
-  )
+  return <AntTransfer {...props} />
 }
 
 Transfer.List = AntTransfer.List

--- a/src/components/data-entry/TreeSelect/TreeSelect.tsx
+++ b/src/components/data-entry/TreeSelect/TreeSelect.tsx
@@ -1,15 +1,10 @@
 import { TreeSelect as AntTreeSelect } from 'antd'
 import { type TreeSelectProps as AntTreeSelectProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ITreeSelectProps extends AntTreeSelectProps {}
 
 export const TreeSelect = (props: ITreeSelectProps) => {
-  return (
-    <ConfigProvider>
-      <AntTreeSelect {...props} />
-    </ConfigProvider>
-  )
+  return <AntTreeSelect {...props} />
 }
 
 TreeSelect.TreeNode = AntTreeSelect.TreeNode

--- a/src/components/data-entry/Upload/Upload.tsx
+++ b/src/components/data-entry/Upload/Upload.tsx
@@ -1,15 +1,11 @@
 import { Upload as AntUpload } from 'antd'
 import { type UploadProps as AntUploadProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface IUploadProps extends AntUploadProps {}
 
 export const Upload = (props: IUploadProps) => {
-  return (
-    <ConfigProvider>
-      <AntUpload {...props} />
-    </ConfigProvider>
-  )
+  return <AntUpload {...props} />
 }
 
 Upload.Dragger = AntUpload.Dragger

--- a/src/components/feedback/Alert/Alert.tsx
+++ b/src/components/feedback/Alert/Alert.tsx
@@ -1,15 +1,10 @@
 import { Alert as AntAlert } from 'antd'
 import { type AlertProps as AntAlertProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IAlertProps extends AntAlertProps {}
 
 export const Alert = (props: IAlertProps) => {
-  return (
-    <ConfigProvider>
-      <AntAlert {...props} />
-    </ConfigProvider>
-  )
+  return <AntAlert {...props} />
 }
 
 Alert.ErrorBoundary = AntAlert.ErrorBoundary

--- a/src/components/feedback/Drawer/Drawer.tsx
+++ b/src/components/feedback/Drawer/Drawer.tsx
@@ -1,13 +1,8 @@
 import { Drawer as AntDrawer } from 'antd'
 import { type DrawerProps as AntDrawerProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IDrawerProps extends AntDrawerProps {}
 
 export const Drawer = (props: IDrawerProps) => {
-  return (
-    <ConfigProvider>
-      <AntDrawer {...props} />
-    </ConfigProvider>
-  )
+  return <AntDrawer {...props} />
 }

--- a/src/components/feedback/Message/Message.tsx
+++ b/src/components/feedback/Message/Message.tsx
@@ -1,6 +1,5 @@
 import { message as AntMessage } from 'antd'
 import { type MessageArgsProps as AntMessageArgsProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IMessageProps extends AntMessageArgsProps {
   children: React.ReactNode
@@ -16,10 +15,10 @@ export const Message = (props: IMessageProps) => {
   }
 
   return (
-    <ConfigProvider>
+    <>
       {contextHolder}
       <span onClick={open}>{props.children}</span>
-    </ConfigProvider>
+    </>
   )
 }
 

--- a/src/components/feedback/Modal/Modal.tsx
+++ b/src/components/feedback/Modal/Modal.tsx
@@ -1,15 +1,10 @@
 import { Modal as AntModal } from 'antd'
 import { type ModalProps as AntModalProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IModalProps extends AntModalProps {}
 
 export const Modal = (props: IModalProps) => {
-  return (
-    <ConfigProvider>
-      <AntModal {...props} />
-    </ConfigProvider>
-  )
+  return <AntModal {...props} />
 }
 
 Modal.info = AntModal.info

--- a/src/components/feedback/Notification/Notification.tsx
+++ b/src/components/feedback/Notification/Notification.tsx
@@ -1,6 +1,5 @@
 import { notification as AntNotification } from 'antd'
 import { type NotificationArgsProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface INotificationProps extends NotificationArgsProps {
   children: React.ReactNode
@@ -16,10 +15,10 @@ export const Notification = (props: INotificationProps) => {
   }
 
   return (
-    <ConfigProvider>
+    <>
       {contextHolder}
       <span onClick={open}>{props.children}</span>
-    </ConfigProvider>
+    </>
   )
 }
 

--- a/src/components/feedback/Popconfirm/Popconfirm.tsx
+++ b/src/components/feedback/Popconfirm/Popconfirm.tsx
@@ -1,17 +1,14 @@
 import { Popconfirm as AntPopconfirm } from 'antd'
 import { type PopconfirmProps as AntPopconfirmProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IPopconfirmProps extends AntPopconfirmProps {}
 
 export const Popconfirm = (props: IPopconfirmProps) => {
   return (
-    <ConfigProvider>
-      <AntPopconfirm {...props}>
-        {/* Fragment fixes tooltip sometimes not showing */}
-        {/* https://github.com/ant-design/ant-design/issues/15909 */}
-        <>{props.children}</>
-      </AntPopconfirm>
-    </ConfigProvider>
+    <AntPopconfirm {...props}>
+      {/* Fragment fixes tooltip sometimes not showing */}
+      {/* https://github.com/ant-design/ant-design/issues/15909 */}
+      <>{props.children}</>
+    </AntPopconfirm>
   )
 }

--- a/src/components/feedback/Progress/Progress.tsx
+++ b/src/components/feedback/Progress/Progress.tsx
@@ -1,13 +1,8 @@
 import { Progress as AntProgress } from 'antd'
 import { type ProgressProps as AntProgressProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IProgressProps extends AntProgressProps {}
 
 export const Progress = (props: IProgressProps) => {
-  return (
-    <ConfigProvider>
-      <AntProgress {...props} />
-    </ConfigProvider>
-  )
+  return <AntProgress {...props} />
 }

--- a/src/components/feedback/Result/Result.tsx
+++ b/src/components/feedback/Result/Result.tsx
@@ -1,15 +1,10 @@
 import { Result as AntResult } from 'antd'
 import { type ResultProps as AntResultProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IResultProps extends AntResultProps {}
 
 export const Result = (props: IResultProps) => {
-  return (
-    <ConfigProvider>
-      <AntResult {...props} />
-    </ConfigProvider>
-  )
+  return <AntResult {...props} />
 }
 
 Result.PRESENTED_IMAGE_403 = AntResult.PRESENTED_IMAGE_403

--- a/src/components/feedback/Skeleton/Skeleton.tsx
+++ b/src/components/feedback/Skeleton/Skeleton.tsx
@@ -1,16 +1,11 @@
 import { Skeleton as AntSkeleton } from 'antd'
 import { type SkeletonProps as AntSkeletonProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ISkeletonProps extends Omit<AntSkeletonProps, 'active'> {}
 
 export const Skeleton = (props: ISkeletonProps) => {
   const defaultWidth = '100%' as const
-  return (
-    <ConfigProvider>
-      <AntSkeleton {...props} active style={{ width: defaultWidth, ...props.style }} />
-    </ConfigProvider>
-  )
+  return <AntSkeleton {...props} active style={{ width: defaultWidth, ...props.style }} />
 }
 
 Skeleton.Avatar = AntSkeleton.Avatar

--- a/src/components/feedback/Spin/Spin.tsx
+++ b/src/components/feedback/Spin/Spin.tsx
@@ -1,15 +1,10 @@
 import { Spin as AntSpin } from 'antd'
 import { type SpinProps as AntSpinProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ISpinProps extends AntSpinProps {}
 
 export const Spin = (props: ISpinProps) => {
-  return (
-    <ConfigProvider>
-      <AntSpin {...props} />
-    </ConfigProvider>
-  )
+  return <AntSpin {...props} />
 }
 
 Spin.setDefaultIndicator = AntSpin.setDefaultIndicator

--- a/src/components/feedback/Watermark/Watermark.tsx
+++ b/src/components/feedback/Watermark/Watermark.tsx
@@ -1,13 +1,8 @@
 import { Watermark as AntWatermark } from 'antd'
 import { type WatermarkProps as AntWatermarkProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IWatermarkProps extends AntWatermarkProps {}
 
 export const Watermark = (props: IWatermarkProps) => {
-  return (
-    <ConfigProvider>
-      <AntWatermark {...props} />
-    </ConfigProvider>
-  )
+  return <AntWatermark {...props} />
 }

--- a/src/components/general/Button/Button.tsx
+++ b/src/components/general/Button/Button.tsx
@@ -1,6 +1,5 @@
 import { Button as AntButton } from 'antd'
 import { type ButtonProps as AntButtonProps } from 'antd'
-import { ConfigProvider } from 'src/components/other/ConfigProvider/ConfigProvider'
 
 export interface IButtonProps extends AntButtonProps {
   /**
@@ -16,11 +15,9 @@ export const Button = (props: IButtonProps) => {
   }
 
   return (
-    <ConfigProvider>
-      <AntButton {...props} className={`${props.className}${props.variant ? ` ${classMap[props.variant]}` : ''}`}>
-        {props.children}
-      </AntButton>
-    </ConfigProvider>
+    <AntButton {...props} className={`${props.className}${props.variant ? ` ${classMap[props.variant]}` : ''}`}>
+      {props.children}
+    </AntButton>
   )
 }
 

--- a/src/components/general/FloatButton/FloatButton.tsx
+++ b/src/components/general/FloatButton/FloatButton.tsx
@@ -1,15 +1,10 @@
 import { FloatButton as AntFloatButton } from 'antd'
 import { type FloatButtonProps as AntFloatButtonProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IFloatButtonProps extends AntFloatButtonProps {}
 
 export const FloatButton = (props: IFloatButtonProps) => {
-  return (
-    <ConfigProvider>
-      <AntFloatButton {...props} />
-    </ConfigProvider>
-  )
+  return <AntFloatButton {...props} />
 }
 
 FloatButton.BackTop = AntFloatButton.BackTop

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -3,7 +3,6 @@ import {
   type TypographyProps as AntTypographyProps,
   ConfigProvider as AntConfigProvider,
 } from 'antd'
-import { ConfigProvider } from 'src/components'
 import { type ReactNode } from 'react'
 import { type TextProps as AntTextProps } from 'antd/es/typography/Text'
 import { type TitleProps as AntTitleProps } from 'antd/es/typography/Title'
@@ -14,11 +13,7 @@ export interface ITypographyProps extends AntTypographyProps {
   children: ReactNode
 }
 
-export const Typography = (props: ITypographyProps) => (
-  <ConfigProvider>
-    <AntTypography {...props}>{props.children}</AntTypography>
-  </ConfigProvider>
-)
+export const Typography = (props: ITypographyProps) => <AntTypography {...props}>{props.children}</AntTypography>
 
 type TypographySize = 'base' | 'sm' | 'lg' | 'xl'
 export interface ITextProps extends AntTextProps {
@@ -46,11 +41,9 @@ const Text = ({ size = 'base', ...props }: ITextProps) => {
   const lineHeight = getLineHeight(size)
 
   return (
-    <ConfigProvider>
-      <AntConfigProvider theme={{ components: { Typography: { fontSize, lineHeight } } }}>
-        <AntTypography.Text {...props}>{props.children}</AntTypography.Text>
-      </AntConfigProvider>
-    </ConfigProvider>
+    <AntConfigProvider theme={{ components: { Typography: { fontSize, lineHeight } } }}>
+      <AntTypography.Text {...props}>{props.children}</AntTypography.Text>
+    </AntConfigProvider>
   )
 }
 
@@ -60,22 +53,14 @@ interface ITitleProps extends AntTitleProps {
   children: ReactNode
 }
 
-const Title = (props: ITitleProps) => (
-  <ConfigProvider>
-    <AntTypography.Title {...props}>{props.children}</AntTypography.Title>
-  </ConfigProvider>
-)
+const Title = (props: ITitleProps) => <AntTypography.Title {...props}>{props.children}</AntTypography.Title>
 Typography.Title = Title
 
 export interface ILinkProps extends AntLinkProps {
   children: ReactNode
 }
 
-const Link = (props: ILinkProps) => (
-  <ConfigProvider>
-    <AntTypography.Link {...props}>{props.children}</AntTypography.Link>
-  </ConfigProvider>
-)
+const Link = (props: ILinkProps) => <AntTypography.Link {...props}>{props.children}</AntTypography.Link>
 Typography.Link = Link
 
 export interface IParagraphProps extends AntParagraphProps {
@@ -83,8 +68,6 @@ export interface IParagraphProps extends AntParagraphProps {
 }
 
 const Paragraph = (props: IParagraphProps) => (
-  <ConfigProvider>
-    <AntTypography.Paragraph {...props}>{props.children}</AntTypography.Paragraph>
-  </ConfigProvider>
+  <AntTypography.Paragraph {...props}>{props.children}</AntTypography.Paragraph>
 )
 Typography.Paragraph = Paragraph

--- a/src/components/layout/Divider/Divider.tsx
+++ b/src/components/layout/Divider/Divider.tsx
@@ -1,13 +1,8 @@
 import { Divider as AntDivider } from 'antd'
 import { type DividerProps as AntDividerProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IDividerProps extends AntDividerProps {}
 
 export const Divider = (props: IDividerProps) => {
-  return (
-    <ConfigProvider>
-      <AntDivider {...props} />
-    </ConfigProvider>
-  )
+  return <AntDivider {...props} />
 }

--- a/src/components/layout/Flex/Flex.tsx
+++ b/src/components/layout/Flex/Flex.tsx
@@ -1,13 +1,8 @@
 import { Flex as AntFlex } from 'antd'
 import { type FlexProps as AntFlexProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IFlexProps extends AntFlexProps {}
 
 export const Flex = (props: IFlexProps) => {
-  return (
-    <ConfigProvider>
-      <AntFlex {...props} />
-    </ConfigProvider>
-  )
+  return <AntFlex {...props} />
 }

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -1,15 +1,10 @@
 import { Layout as AntLayout } from 'antd'
 import { type LayoutProps as AntLayoutProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ILayoutProps extends AntLayoutProps {}
 
 export const Layout = (props: ILayoutProps) => {
-  return (
-    <ConfigProvider>
-      <AntLayout {...props} />
-    </ConfigProvider>
-  )
+  return <AntLayout {...props} />
 }
 
 Layout.Sider = AntLayout.Sider

--- a/src/components/layout/Space/Space.tsx
+++ b/src/components/layout/Space/Space.tsx
@@ -1,15 +1,10 @@
 import { Space as AntSpace } from 'antd'
 import { type SpaceProps as AntSpaceProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface ISpaceProps extends AntSpaceProps {}
 
 export const Space = (props: ISpaceProps) => {
-  return (
-    <ConfigProvider>
-      <AntSpace {...props} />
-    </ConfigProvider>
-  )
+  return <AntSpace {...props} />
 }
 
 Space.Compact = AntSpace.Compact

--- a/src/components/navigation/Anchor/Anchor.tsx
+++ b/src/components/navigation/Anchor/Anchor.tsx
@@ -1,14 +1,9 @@
 import { Anchor as AntAnchor } from 'antd'
 import { type AnchorProps as AntAnchorProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IAnchorProps extends AntAnchorProps {}
 
 export const Anchor = (props: IAnchorProps) => {
-  return (
-    <ConfigProvider>
-      <AntAnchor {...props} />
-    </ConfigProvider>
-  )
+  return <AntAnchor {...props} />
 }
 Anchor.Link = AntAnchor.Link

--- a/src/components/navigation/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/navigation/Breadcrumb/Breadcrumb.tsx
@@ -1,15 +1,10 @@
 import { Breadcrumb as AntBreadcrumb } from 'antd'
 import { type BreadcrumbProps as AntBreadcrumbProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IBreadcrumbProps extends AntBreadcrumbProps {}
 
 export const Breadcrumb = (props: IBreadcrumbProps) => {
-  return (
-    <ConfigProvider>
-      <AntBreadcrumb {...props} />
-    </ConfigProvider>
-  )
+  return <AntBreadcrumb {...props} />
 }
 
 Breadcrumb.Item = AntBreadcrumb.Item

--- a/src/components/navigation/Dropdown/Dropdown.tsx
+++ b/src/components/navigation/Dropdown/Dropdown.tsx
@@ -1,15 +1,10 @@
 import { Dropdown as AntDropdown } from 'antd'
 import { type DropdownProps as AntDropdownProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IDropdownProps extends AntDropdownProps {}
 
 export const Dropdown = (props: IDropdownProps) => {
-  return (
-    <ConfigProvider>
-      <AntDropdown {...props}>{props.children}</AntDropdown>
-    </ConfigProvider>
-  )
+  return <AntDropdown {...props}>{props.children}</AntDropdown>
 }
 
 Dropdown.Button = AntDropdown.Button

--- a/src/components/navigation/Menu/Menu.tsx
+++ b/src/components/navigation/Menu/Menu.tsx
@@ -7,7 +7,6 @@ import {
   type SubMenuType as AndSubMenuType,
 } from 'antd/es/menu/hooks/useItems'
 import { type MenuInfo as RCMenuInfo } from 'rc-menu/lib/interface'
-import { ConfigProvider } from 'src/components'
 
 export interface IMenuProps extends AntMenuProps {}
 
@@ -21,11 +20,7 @@ export {
 }
 
 export const Menu = (props: IMenuProps) => {
-  return (
-    <ConfigProvider>
-      <AntMenu {...props} />
-    </ConfigProvider>
-  )
+  return <AntMenu {...props} />
 }
 
 Menu.SubMenu = AntMenu.SubMenu

--- a/src/components/navigation/MiniMap/MiniMap.tsx
+++ b/src/components/navigation/MiniMap/MiniMap.tsx
@@ -29,19 +29,17 @@ const Minimap = (props: IMiniMapProps) => {
   }))
 
   return (
-    <ConfigProvider>
-      <div className="u-padding-sm">
-        <Flex align="normal" component="div" flex="0 1 auto" gap="small" justify="stretch" vertical wrap="nowrap">
-          <Flex align="center" justify="space-between">
-            <Logo />
-            <Button href={props.overviewHref || '/'}>Go to overview</Button>
-          </Flex>
-          <SvgLinker links={svgLinks} onLinkClick={handleLinkClick}>
-            {minimap}
-          </SvgLinker>
+    <div className="u-padding-sm">
+      <Flex align="normal" component="div" flex="0 1 auto" gap="small" justify="stretch" vertical wrap="nowrap">
+        <Flex align="center" justify="space-between">
+          <Logo />
+          <Button href={props.overviewHref || '/'}>Go to overview</Button>
         </Flex>
-      </div>
-    </ConfigProvider>
+        <SvgLinker links={svgLinks} onLinkClick={handleLinkClick}>
+          {minimap}
+        </SvgLinker>
+      </Flex>
+    </div>
   )
   function handleLinkClick(svgLink: ISvgLink): void {
     const miniMapLink = props.links.find(link => link.href === svgLink.href)!

--- a/src/components/navigation/Pagination/Pagination.tsx
+++ b/src/components/navigation/Pagination/Pagination.tsx
@@ -1,13 +1,8 @@
 import { Pagination as AntPagination } from 'antd'
 import { type PaginationProps as AntPaginationProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IPaginationProps extends AntPaginationProps {}
 
 export const Pagination = (props: IPaginationProps) => {
-  return (
-    <ConfigProvider>
-      <AntPagination {...props} />
-    </ConfigProvider>
-  )
+  return <AntPagination {...props} />
 }

--- a/src/components/navigation/Steps/Steps.tsx
+++ b/src/components/navigation/Steps/Steps.tsx
@@ -1,13 +1,8 @@
 import { Steps as AntSteps } from 'antd'
 import { type StepsProps as AntStepsProps } from 'antd'
-import { ConfigProvider } from 'src/components'
 
 export interface IStepsProps extends AntStepsProps {}
 
 export const Steps = (props: IStepsProps) => {
-  return (
-    <ConfigProvider>
-      <AntSteps {...props} />
-    </ConfigProvider>
-  )
+  return <AntSteps {...props} />
 }

--- a/src/components/other/Affix/Affix.tsx
+++ b/src/components/other/Affix/Affix.tsx
@@ -1,13 +1,9 @@
 import { Affix as AntAffix } from 'antd'
 import { type AffixProps as AntAffixProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface IAffixProps extends AntAffixProps {}
 
 export const Affix = (props: IAffixProps) => {
-  return (
-    <ConfigProvider>
-      <AntAffix {...props} />
-    </ConfigProvider>
-  )
+  return <AntAffix {...props} />
 }

--- a/src/components/other/App/App.tsx
+++ b/src/components/other/App/App.tsx
@@ -1,15 +1,11 @@
 import { App as AntApp } from 'antd'
 import { type AppProps as AntAppProps } from 'antd'
-import { ConfigProvider } from 'src/components'
+
 
 export interface IAppProps extends AntAppProps {}
 
 export const App = (props: IAppProps) => {
-  return (
-    <ConfigProvider>
-      <AntApp {...props} />
-    </ConfigProvider>
-  )
+  return <AntApp {...props} />
 }
 
 App.useApp = AntApp.useApp


### PR DESCRIPTION
## Instructions

1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary

- Adds a global storybook decorator and removes all nested config providers around all components. 
- 🔴 Requires the branch this is stacked on top of and changes in indicative, cortex, and nancy to render a ConfigProvider imported from aquarium at the root of their react trees 🔴 

## Testing Plan

- [x] Was this tested locally? If not, explain why.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
