### PR TITLE
fix: lazy load ValueSelector to fix Storybook test runner

### DIFF
--- a/src/components/data-entry/QueryItem/ValueSelector.stories.tsx
+++ b/src/components/data-entry/QueryItem/ValueSelector.stories.tsx
@@ -1,9 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react'
-import ValueSelector from './ValueSelector'
+import type ValueSelector from './ValueSelector'
+import { Suspense, lazy } from 'react'
+
+const _ValueSelector = lazy(async () => await import('./ValueSelector'))
 
 const meta: Meta<typeof ValueSelector> = {
   title: 'Aquarium/Data Entry/QueryItem/ValueSelector',
-  component: ValueSelector,
+  component: _ValueSelector,
   parameters: {
     docs: {
       description: {
@@ -12,7 +15,13 @@ const meta: Meta<typeof ValueSelector> = {
       },
     },
   },
-
+  decorators: [
+    Story => (
+      <Suspense>
+        <Story />
+      </Suspense>
+    ),
+  ],
   args: {},
 }
 export default meta


### PR DESCRIPTION
## Instructions

1. PR target branch should be against `main`
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

## Summary

Automated tests run with `npm run test-storybook` would fail consistently on the ValueSelector story, citing:
```
error: ReferenceError: Cannot access 'ValueSelector' before initialization
```

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://mparticle-eng.atlassian.net/browse/UNI-742
