### PR TITLE
chore/more icons typed

### DIFF
--- a/src/components/data-display/Avatar/Avatar.stories.tsx
+++ b/src/components/data-display/Avatar/Avatar.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof Avatar> = {
       options: ['Users', 'Sparkles'],
       mapping: {
         Users: <Icon name="users" />,
-        Sparkles: <Icon name="sparkles" />,
+        Sparkles: <Icon name="sparkles" type="duo"/>,
       },
     },
   },

--- a/src/components/data-entry/QueryItem/Cascader.tsx
+++ b/src/components/data-entry/QueryItem/Cascader.tsx
@@ -22,7 +22,7 @@ export interface ICascaderOption {
 
 export interface ICascaderProps {
   options: ICascaderOption[]
-  icon?: keyof Pick<typeof Icons, 'empty' | 'event' | 'userAttribute' | 'eventAttribute'>
+  icon?: keyof Pick<Icons, 'empty' | 'event' | 'userAttribute' | 'eventAttribute'>
   errorMessage?: string
   placeholder?: string
   onChange?: (values: Array<number | string>, selectedOptions: any) => Promise<void>

--- a/src/components/general/Icon/Icon.stories.tsx
+++ b/src/components/general/Icon/Icon.stories.tsx
@@ -1,7 +1,8 @@
 import { type Meta } from '@storybook/react'
-import React, { ReactNode } from 'react'
-import { Flex, Icon, type IIconProps } from 'src/components'
-import { Icons } from 'src/constants/Icons'
+import React, { type ReactNode } from 'react'
+import { Flex, Icon } from 'src/components'
+import {type IIconProps} from 'src/components/general/Icon/Icon'
+import { DuoIcons, LightIcons } from 'src/constants/Icons'
 
 export const IconTable: React.FC<IIconProps> = ({ color = 'black', size = 'lg', name }) => {
   return (
@@ -13,16 +14,27 @@ export const IconTable: React.FC<IIconProps> = ({ color = 'black', size = 'lg', 
         alignItems: 'center',
         justifyItems: 'center',
       }}>
-      {name // render either a single selected icon, or all possible icons
-        ? renderIcon(name, size, color)
-        : (Object.keys(Icons) as Array<keyof typeof Icons>).map(iconName => renderIcon(iconName, size, color))}
+      {/* renders either a single selected icon, or all possible icons */}
+      {name ? (
+        renderIcon(name, size, color)
+      ) : (
+        <>
+          {(Object.keys(LightIcons) as Array<keyof typeof LightIcons>).map(iconName => renderIcon(iconName, size, color, 'light'))}
+          {(Object.keys(DuoIcons) as Array<keyof typeof DuoIcons>).map(iconName => renderIcon(iconName, size, color, 'duo'))}
+        </>
+      )}
     </div>
   )
 
-  function renderIcon(iconName: IIconProps['name'], size: IIconProps['size'], color: IIconProps['color']): ReactNode {
+  function renderIcon(
+    iconName: IIconProps['name'],
+    size: IIconProps['size'],
+    color: IIconProps['color'],
+    type?: IIconProps['type'],
+  ): ReactNode {
     return (
       <Flex vertical align="center" key={iconName}>
-        <Icon name={iconName} size={size} color={color} key={iconName} />
+        <Icon name={iconName} size={size} color={color} type={type} key={iconName} />
         <p style={{ fontFamily: 'monospace' }}>{iconName}</p>
       </Flex>
     )

--- a/src/components/general/Icon/Icon.tsx
+++ b/src/components/general/Icon/Icon.tsx
@@ -1,4 +1,5 @@
-import { DuoIcons, LightIcons } from 'src/constants/Icons'
+import { type ReactNode } from 'react'
+import { DuoIcons, type Icons, LightIcons } from 'src/constants/Icons'
 import './icon.css'
 
 type IconSize = 'xxxxl' | 'xxxl' | 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs'
@@ -15,20 +16,36 @@ export type IconColor =
   | 'strong'
   | 'brand'
 
-export interface IIconProps {
-  name//: if type==='duo' then name is keyof typeof DuoIcons, else if type==='light' then name is keyof typeof LightIcons
+export interface IBaseIconProps {
+  name: keyof Icons // : IIconProps['name']
   color?: IconColor
   size?: IconSize
   type: 'duo' | 'light'
 }
 
+export interface ILightIconProps extends IBaseIconProps {
+  name: keyof typeof LightIcons
+  type: 'light'
+}
+
+export interface IDuoIconProps extends IBaseIconProps {
+  name: keyof typeof DuoIcons
+  type: 'duo'
+}
+
+export type IIconProps = ILightIconProps | IDuoIconProps
+
 export const Icon = (props: IIconProps) => {
-  let IconName: IIconProps['name']
+  let IconName: any
 
   if (props.type === 'duo') {
-    IconName = DuoIcons[props.name]
-  } else if (props.type === 'light') {
-    IconName = LightIcons[props.name]
+    props.name = props.name as keyof typeof DuoIcons
+    IconName = DuoIcons[props.name] as unknown as ReactNode
+  }
+
+  if (props.type === 'light') {
+    props.name = props.name as keyof typeof LightIcons
+    IconName = LightIcons[props.name] as unknown as ReactNode
   }
 
   const className = `icon-size-${props.size} icon-color-${props.color}`

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -31,12 +31,12 @@ import LockIcon from 'src/assets/svg/lock.svg?react'
 import MessageQuestionIcon from 'src/assets/svg/message-question.svg?react'
 import MpLogoIcon from 'src/assets/svg/mpLogo.svg?react'
 import ObservabilityIcon from 'src/assets/svg/mp_pm_lt_observability.svg?react'
-import OversightIcon from 'src/assets/svg/mp_pm_dt_oversight.svg?react'
+import OversightIconDuo from 'src/assets/svg/mp_pm_dt_oversight.svg?react'
 import PredictionsIconLight from 'src/assets/svg/mp_pm_lt_predictions.svg?react'
 import PredictionsIconDuo from 'src/assets/svg/mp_pm_dt_predictions.svg?react'
 import RemoveIcon from 'src/assets/svg/remove.svg?react'
 import SearchIcon from 'src/assets/svg/search.svg?react'
-import SegmentationIcon from 'src/assets/svg/mp_pm_dt_segmentation.svg?react'
+import SegmentationIconDuo from 'src/assets/svg/mp_pm_dt_segmentation.svg?react'
 import ShieldKeyholeIcon from 'src/assets/svg/shield-keyhole.svg?react'
 import SignoutIcon from 'src/assets/svg/signout.svg?react'
 import SplitIcon from 'src/assets/svg/split.svg?react'
@@ -87,12 +87,12 @@ export {
   MessageQuestionIcon,
   MpLogoIcon,
   ObservabilityIcon,
-  OversightIcon,
+  OversightIconDuo,
   PredictionsIconDuo,
   PredictionsIconLight,
   RemoveIcon,
   SearchIcon,
-  SegmentationIcon,
+  SegmentationIconDuo,
   ShieldKeyholeIcon,
   SignoutIcon,
   SplitIcon,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 export { Button, type IButtonProps } from './general/Button/Button'
 export { FloatButton, type IFloatButtonProps } from './general/FloatButton/FloatButton'
-export { Icon, type IIconProps } from './general/Icon/Icon'
+export { Icon, type IBaseIconProps } from './general/Icon/Icon'
 export { Rate, type IRateProps } from './data-entry/Rate/Rate'
 export { Form, type IFormProps } from './data-entry/Form/Form'
 export { TreeSelect, type ITreeSelectProps } from './data-entry/TreeSelect/TreeSelect'

--- a/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
@@ -1,6 +1,6 @@
 import type { ReactNode, type MouseEvent, ReactElement } from 'react'
 import { type HrefOptions } from 'src/utils/utils'
-import { Icons } from 'src/constants/Icons'
+import {type Icons } from 'src/constants/Icons'
 
 export interface IBaseGlobalNavigationItem {
   type?: 'menu' | 'link'
@@ -13,7 +13,7 @@ export interface IBaseGlobalNavigationItem {
 export interface IGlobalNavigationLogo extends IBaseGlobalNavigationItem {
   onSuiteLogoClick: () => void
   type?: 'default' | 'background-solid' | 'custom-size'
-  icon?: ReactElement | keyof typeof Icons
+  icon?: ReactElement | keyof Icons
 }
 
 export interface IGlobalNavigationMenu extends IBaseGlobalNavigationItem {

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -1,14 +1,14 @@
-import React, { ReactElement, ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 import { Center, Icon } from 'src/components'
-import { NavigationIcon } from 'src/components/navigation/GlobalNavigation/NavigationIcon'
-import { Icons } from 'src/constants/Icons'
+import { type IconColor } from 'src/components/general/Icon/Icon'
 import { type IGlobalNavigationLogo } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
-import { IconColor } from 'src/components/general/Icon/Icon'
+import { NavigationIcon } from 'src/components/navigation/GlobalNavigation/NavigationIcon'
+import { type DuoIcons, type Icons } from 'src/constants/Icons'
 
 // custom-size is the default size to prevent breaking changes.
 type IconColorOptions = 'default' | 'background-solid' | 'custom-size'
 
-function isStringIcon(icon: ReactNode | string): icon is keyof typeof Icons {
+function isStringIcon(icon: ReactNode | string): icon is keyof Icons {
   return typeof icon === 'string'
 }
 
@@ -27,7 +27,7 @@ export function SuiteLogo({ icon, label, type = 'custom-size', onSuiteLogoClick 
 
   const getIcon = () => {
     if (isStringIcon(icon)) {
-      return <Icon name={icon} color={iconColorMap[type]} size="xl" />
+      return <Icon name={icon as keyof typeof DuoIcons} color={iconColorMap[type]} size="xl" type="duo" />
     }
     return icon
   }

--- a/src/constants/Icons.ts
+++ b/src/constants/Icons.ts
@@ -10,8 +10,9 @@ import {
   CircleNodesIcon,
   CloudIcon,
   ConnectionsIcon,
-  DataPlatformDuo,
+  ConversionIcon,
   DatabaseIcon,
+  DataPlatformDuo,
   DsrIcon,
   EmptyIcon,
   EnrichmentIcon,
@@ -24,6 +25,7 @@ import {
   GridIcon,
   HeartIcon,
   HelpIcon,
+  HelpVideoIcon,
   IdentityIcon,
   JumpToIcon,
   LightBulbIcon,
@@ -32,11 +34,13 @@ import {
   MessageQuestionIcon,
   MpLogoIcon,
   ObservabilityIcon,
-  OversightIcon,
+  OversightIconDuo,
+  PredictionsIconDuo,
   PredictionsIconLight,
+  PremiumIcon,
   RemoveIcon,
   SearchIcon,
-  SegmentationIcon,
+  SegmentationIconDuo,
   ShieldKeyholeIcon,
   SignoutIcon,
   SplitIcon,
@@ -49,17 +53,15 @@ import {
   WrenchIcon,
   ZoomIn,
   ZoomOut,
-  PremiumIcon,
-  HelpVideoIcon,
-  ConversionIcon,
-  PredictionsIconDuo,
 } from 'src/components/icons'
 
 export const DuoIcons = {
   analytics: AnalyticsIconDuo,
   C360: C360IconDuo,
   siteMap: DataPlatformDuo,
+  oversight: OversightIconDuo,
   sparkles: PredictionsIconDuo,
+  segmentation: SegmentationIconDuo,
 } as const
 
 export const LightIcons = {
@@ -93,10 +95,8 @@ export const LightIcons = {
   messageQuestion: MessageQuestionIcon,
   mpLogo: MpLogoIcon,
   observability: ObservabilityIcon,
-  oversight: OversightIcon,
   remove: RemoveIcon,
   search: SearchIcon,
-  segmentation: SegmentationIcon,
   shieldKeyhole: ShieldKeyholeIcon,
   signout: SignoutIcon,
   predictions: PredictionsIconLight,
@@ -114,3 +114,5 @@ export const LightIcons = {
   helpVideo: HelpVideoIcon,
   conversion: ConversionIcon,
 } as const
+
+export type Icons = typeof DuoIcons & typeof LightIcons


### PR DESCRIPTION
# THIS WILL BE A BREAKING CHANGE
- todo:  will need to rename branch to `feat/`

## Summary
we will want to support having icons with the same name but a different type
for example, types DuoTone and Light are both used today in the platforms
but there are currently no cases of using one icon name with two types
we should support this because design expects it


## Testing Plan
testing done on story book [Icons](http://localhost:6006/?path=/docs/aquarium-general-icons--documentation) page 


## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- Closes https://go.mparticle.com/work/REPLACEME
