### PR TITLE
chore: replace '_' with '-' during release

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -3,17 +3,17 @@ module.exports = {
     {
       name: 'feat/*',
       channel: 'feature',
-      prerelease: "${name.split('/').slice(1).join('-').toLowerCase()}"
+      prerelease: "${name.split('/').slice(1).join('-').toLowerCase().replaceAll('_', '-')}"
     },
     {
       name: 'chore/*',
       channel: 'chore',
-      prerelease: "chore-${name.split('/').slice(1).join('-').toLowerCase()}"
+      prerelease: "chore-${name.split('/').slice(1).join('-').toLowerCase().replaceAll('_', '-')}"
     },
     {
       name: 'fix/*',
       channel: 'fix',
-      prerelease: "fix-${name.split('/').slice(1).join('-').toLowerCase()}"
+      prerelease: "fix-${name.split('/').slice(1).join('-').toLowerCase().replaceAll('_', '-')}"
     },
     
   ],


### PR DESCRIPTION
## Instructions
> No need to keep instructions in the final PR description

Fixes release workflow for branches that use '_', which is not valid under semantic versioning. 

1. PR target branch should be against `main`
2. PR title prefix should state semantic value for the change, usually `feat:`, `fix:` or `chore:`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml)
3. PR branch prefix should state the same as the above with a `/`, usually `feat/`, `fix/` or `chore/`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml)

## Summary

- {provide a thorough description of the changes}

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
