### PR TITLE
Chore: QueryItem Cascader, TextInput and NumberInput adding extra functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1](https://github.com/mParticle/aquarium/compare/v1.21.0...v1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1) (2024-07-19)
+
+### Bug Fixes
+
+- a useEffect Hook has been added to detect if the value received from parameter changed ([d8c6f10](https://github.com/mParticle/aquarium/commit/d8c6f10b7ed3df7e742b0fb23a0657bf0102e843))
+- extra validation added to cascader selectedDisplayValue state ([ed3e159](https://github.com/mParticle/aquarium/commit/ed3e15910a1485b4426b49b13a72c8e4fe1dbda3))
+
 ## [1.21.1-fix-queryitem.valueselector.cascader-various-fixes.1](https://github.com/mParticle/aquarium/compare/v1.21.0...v1.21.1-fix-queryitem.valueselector.cascader-various-fixes.1) (2024-07-19)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.21.1-fix-queryitem.valueselector.cascader-various-fixes.1",
+  "version": "1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.21.1-fix-queryitem.valueselector.cascader-various-fixes.1",
+      "version": "1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.21.1-fix-queryitem.valueselector.cascader-various-fixes.1",
+  "version": "1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.21.1-chore-queryitem.valueselector-adding-extra-functionality.1",
+  "version": "1.21.0",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/components/data-entry/QueryItem/NumberInput.tsx
+++ b/src/components/data-entry/QueryItem/NumberInput.tsx
@@ -13,6 +13,7 @@ export interface INumberInputProps {
   step?: number
   onChange?: (value: number | undefined) => void
   onPressEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  className?: string
 }
 
 const NumberInput = (props: INumberInputProps) => {
@@ -20,6 +21,7 @@ const NumberInput = (props: INumberInputProps) => {
 
   let inputClasses = `query-item query-item--input-number`
   if (props.errorMessage) inputClasses += ' query-item--error'
+  if (props.className) inputClasses += ` ${props.className}`
 
   const handleOnChange = (value: string | number | null | undefined) => {
     const floatValue = parseFloat(value as string)

--- a/src/components/data-entry/QueryItem/TextInput.tsx
+++ b/src/components/data-entry/QueryItem/TextInput.tsx
@@ -8,6 +8,7 @@ interface ITextInputProps {
   errorMessage?: string
   placeholder?: string
   onChange?: (value: string) => void
+  className?: string
 }
 
 const TextInput = (props: ITextInputProps) => {
@@ -15,6 +16,7 @@ const TextInput = (props: ITextInputProps) => {
 
   let inputClasses = `query-item query-item--input-text`
   if (props.errorMessage) inputClasses += ' query-item--error'
+  if (props.className) inputClasses += ` ${props.className}`
 
   return (
     <>


### PR DESCRIPTION
## Summary

- TextInput Component now has className prop.
- NumberInput Component now has className prop.
- Cascader Component now has classNameInput prop.
- useEffect Hook was added con Cascader to dectect if value prop changes

## Testing Plan

- [x] Was this tested locally? 
- Tested on Nancy, importing release branch.

- Closes https://go.mparticle.com/work/UI3DM-1334
