### PR TITLE
fix: workspace selector positioning

### DIFF
--- a/src/components/navigation/GlobalNavigation/WorkspaceSelector/workspace-selector.css
+++ b/src/components/navigation/GlobalNavigation/WorkspaceSelector/workspace-selector.css
@@ -34,6 +34,14 @@
 
 .workspaceSelector__avatar {
   color: white !important;
+  top: 1px;
+  margin-top: 2px;
+}
+
+.workspaceSelector__label {
+  position: relative;
+  top: 2px;
+  padding-top: var(--padding-xxs);
 }
 
 .workspaceSelector__popover {

--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -1,5 +1,6 @@
 :root {
   --nav-item-height: 56px;
+  --nav-item-height-large: 64px;
   --nav-item-width: 82px;
   --nav-width: 90px;
   --suite-logo-height: 82px;
@@ -90,6 +91,10 @@
   margin: 0 !important;
   background-color: transparent !important;
   cursor: revert !important;
+}
+
+.globalNavigation__item.workspaceSelector__menuItem{
+  height: var(--nav-item-height-large) !important;
 }
 
 .globalNavigation__item .ant-menu-title-content {

--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -1,6 +1,6 @@
 :root {
   --nav-item-height: 56px;
-  --nav-item-height-large: 64px;
+  --nav-item-height-large: 94px;
   --nav-item-width: 82px;
   --nav-width: 90px;
   --suite-logo-height: 82px;


### PR DESCRIPTION
## Summary

Adjusts the height of the Workspace Selector in nav to be 94px (matching vertical padding of other nav elements) and better positions the avatar/text. 

![image](https://github.com/user-attachments/assets/f398c005-4315-4fd3-8bab-7c5d0d40041e)


## Testing Plan

- [x] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://mparticle-eng.atlassian.net/browse/UNI-816
