### PR TITLE
chore/ export for ITextInputProps interface has been added

### DIFF
--- a/src/components/data-entry/QueryItem/TextInput.tsx
+++ b/src/components/data-entry/QueryItem/TextInput.tsx
@@ -2,7 +2,7 @@ import './query-item.css'
 import { Input } from 'src/components'
 import { Typography } from 'src/components/general/Typography/Typography'
 
-interface ITextInputProps {
+export interface ITextInputProps {
   value?: string
   disabled?: boolean
   errorMessage?: string

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ export { Transfer, type ITransferProps } from './data-entry/Transfer/Transfer'
 export { QueryItem } from './data-entry/QueryItem/QueryItem'
 export type { IQueryItemQualifierOption } from './data-entry/QueryItem/Qualifier'
 export type { INumberInputProps } from './data-entry/QueryItem/NumberInput'
+export type { ITextInputProps } from './data-entry/QueryItem/TextInput'
 export { Collapse, type ICollapseProps } from './data-display/Collapse/Collapse'
 export { Timeline, type ITimelineProps } from './data-display/Timeline/Timeline'
 export { Calendar, type ICalendarProps } from './data-display/Calendar/Calendar'
@@ -39,7 +40,14 @@ export { Badge, type IBadgeProps } from './data-display/Badge/Badge'
 export { Card, type ICardProps } from './data-display/Card/Card'
 export { Avatar, type IAvatarProps } from './data-display/Avatar/Avatar'
 export { Descriptions, type IDescriptionsProps } from './data-display/Descriptions/Descriptions'
-export { Table, type ITableProps, type ColumnsType, type ExpandableConfig, type ColumnType, type TableProps } from './data-display/Table/Table'
+export {
+  Table,
+  type ITableProps,
+  type ColumnsType,
+  type ExpandableConfig,
+  type ColumnType,
+  type TableProps,
+} from './data-display/Table/Table'
 export { Empty, type IEmptyProps } from './data-display/Empty/Empty'
 export { Popover, type IPopoverProps } from './data-display/Popover/Popover'
 export { List, type IListProps } from './data-display/List/List'


### PR DESCRIPTION
## Summary

- Export added for ITextInputProps

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/UI3DM-1351
