### PR TITLE
feat: Allow override theme for ConfigProvider using a passed in prop

### DIFF
--- a/src/components/other/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/other/ConfigProvider/ConfigProvider.tsx
@@ -5,7 +5,7 @@ import { LightTheme } from 'design/LightTheme'
 export interface IConfigProviderProps extends AntConfigProviderProps {}
 
 export const ConfigProvider = (props: IConfigProviderProps) => {
-  return <AntConfigProvider {...props} theme={LightTheme} />
+  return <AntConfigProvider theme={LightTheme} {...props} />
 }
 
 ConfigProvider.ConfigContext = AntConfigProvider.ConfigContext


### PR DESCRIPTION
## Instructions
> No need to keep instructions in the final PR description

1. PR target branch should be against `main`
2. PR title prefix should state semantic value for the change, usually `feat:`, `fix:` or `chore:`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml)
3. PR branch prefix should state the same as the above with a `/`, usually `feat/`, `fix/` or `chore/`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml)

## Summary

Antd allows nesting of the ConfigProvider (and inheriting of the nesting). The `theme` also allows for overriding Component tokens. We should allow overriding the `theme` with a passed in prop so we can [override tokens](https://stackoverflow.com/questions/75855462/how-can-i-override-colours-and-styles-of-components-in-ant-design-version-5) in certain contexts, like this:

```
            <ConfigProvider
                theme={{
                    components: {
                        Collapse: {
                            headerPadding: "2px 0",
                            contentPadding: "0 24px",
                        },
                    },
                }}
            >
                <Collapse ...../>
            </ConfigProvider>
```

<img width="583" alt="image" src="https://github.com/user-attachments/assets/74a91915-89c0-430e-b0f7-f81265aaa450">


## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
