### PR TITLE
feat: update SuiteLogo in GlobalNav to render nav switcher Tour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.27.0-global-nav-switcher-tour-component.1](https://github.com/mParticle/aquarium/compare/v1.26.0...v1.27.0-global-nav-switcher-tour-component.1) (2024-08-13)
+
+### Bug Fixes
+
+- add width auto to be able to manage the wdith from the component ([#368](https://github.com/mParticle/aquarium/issues/368)) ([b47c45f](https://github.com/mParticle/aquarium/commit/b47c45f029f49428eb22576971d2e6299ab9acc7))
+- icon color not changing on button hover ([#363](https://github.com/mParticle/aquarium/issues/363)) ([aa07067](https://github.com/mParticle/aquarium/commit/aa07067eecca986208a9b7ff4737077193c83d41))
+
+### Features
+
+- add overview dt icon ([#362](https://github.com/mParticle/aquarium/issues/362)) ([78d7854](https://github.com/mParticle/aquarium/commit/78d7854eec0b7ad0762aa95dd7310d187102e12b))
+- update SuiteLogo to render nav switcher tour ([6098374](https://github.com/mParticle/aquarium/commit/609837455f3f8c3014b9cd007b5efab9d096ff63))
+
 # [1.26.0](https://github.com/mParticle/aquarium/compare/v1.25.1...v1.26.0) (2024-08-07)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.26.0",
+  "version": "1.27.0-global-nav-switcher-tour-component.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.26.0",
+      "version": "1.27.0-global-nav-switcher-tour-component.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.26.0",
+  "version": "1.27.0-global-nav-switcher-tour-component.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/components/data-display/Tour/Tour.stories.tsx
+++ b/src/components/data-display/Tour/Tour.stories.tsx
@@ -1,5 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react'
-import { Tour } from 'src/components/data-display/Tour/Tour'
+import React, { useRef, useState } from 'react'
+import { type ITourProps, Tour } from 'src/components/data-display/Tour/Tour'
+import { Button, Icon, SuiteLogo } from 'src/components'
 
 const meta: Meta<typeof Tour> = {
   title: 'Aquarium/Data Display/Tour',
@@ -12,3 +14,92 @@ export default meta
 type Story = StoryObj<typeof Tour>
 
 export const Primary: Story = {}
+
+export const ExamplePlacement: Story = {
+  render: () => {
+    const ref = useRef(null)
+    const [open, setOpen] = useState<boolean>(false)
+
+    const steps: ITourProps['steps'] = [
+      {
+        title: 'Center',
+        description: 'Displayed in the center of screen.',
+        target: null,
+      },
+      {
+        title: 'Right',
+        description: 'On the right of target.',
+        placement: 'right',
+        target: () => ref.current,
+      },
+      {
+        title: 'Top',
+        description: 'On the top of target.',
+        placement: 'top',
+        target: () => ref.current,
+      },
+    ]
+
+    return (
+      <>
+        <div ref={ref}>
+          <Button
+            type="primary"
+            onClick={() => {
+              setOpen(true)
+            }}>
+            Begin Tour
+          </Button>
+        </div>
+
+        <Tour
+          open={open}
+          onClose={() => {
+            setOpen(false)
+          }}
+          steps={steps}
+        />
+      </>
+    )
+  },
+}
+
+export const ExampleNavLogo: Story = {
+  render: () => {
+    const ref = useRef(null)
+    const [open, setOpen] = useState<boolean>(false)
+
+    const steps: ITourProps['steps'] = [
+      {
+        title: 'Navigate mParticle effortlessly!',
+        description: 'Switch between product suites anytime using this selector.',
+        placement: 'right',
+        target: () => ref.current,
+      },
+    ]
+
+    return (
+      <>
+        <div ref={ref}>
+          <SuiteLogo
+            label="Data Platform"
+            icon={<Icon name="siteMap" />}
+            onSuiteLogoClick={() => {
+              setOpen(true)
+            }}
+          />
+        </div>
+
+        <Tour
+          mask={false}
+          type="primary"
+          open={open}
+          onClose={() => {
+            setOpen(false)
+          }}
+          steps={steps}
+        />
+      </>
+    )
+  },
+}

--- a/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -1200,7 +1200,7 @@ export const MPWithNavSwitcherTour: Story = {
         setOpen(currentOpen => !currentOpen)
       },
       navSwitcherTourOptions: {
-        isOpen: open,
+        open,
         onClose: () => {
           setOpen(false)
         },

--- a/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -1197,7 +1197,7 @@ export const MPWithNavSwitcherTour: Story = {
       icon: 'catalog',
       type: 'background-solid',
       onSuiteLogoClick: () => {
-        setOpen(!open)
+        setOpen(currentOpen => !currentOpen)
       },
       navSwitcherTourOptions: {
         isOpen: open,

--- a/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 import { expect, fn, screen, userEvent } from '@storybook/test'
-import React from 'react'
+import React, { useState } from 'react'
 import { Button, Center, Flex, GlobalNavigation, Icon, type INavigationCreateProps, Space } from 'src/components'
 import { Badge } from 'src/components/data-display/Badge/Badge'
 import {
@@ -1178,5 +1178,51 @@ export const MPWithoutCustomSizeLogo: Story = {
       alt: 'avatar',
     },
     showSuiteLogo: true,
+  },
+}
+
+export const MPWithNavSwitcherTour: Story = {
+  render: () => {
+    const [open, setOpen] = useState<boolean>(false)
+
+    const navigationButtonItemOptions = {
+      label: 'Sign Out of mParticle',
+      onClick: () => {
+        alert('Signout!')
+      },
+    }
+
+    const mpLogoWithTour: IGlobalNavigationLogo = {
+      label: 'Data Platform',
+      icon: 'catalog',
+      type: 'background-solid',
+      onSuiteLogoClick: () => {
+        setOpen(!open)
+      },
+      navSwitcherTourOptions: {
+        isOpen: open,
+        onClose: () => {
+          setOpen(false)
+        },
+      },
+    }
+
+    return (
+      <div style={{ width: 800 }}>
+        <GlobalNavigation
+          onSearchClick={() => {
+            alert('Searching!')
+          }}
+          logo={mpLogoWithTour}
+          tools={mpTools}
+          management={mpManagement}
+          orgs={mpOrgs}
+          onMpHomeClick={() => {
+            alert('going to overview map')
+          }}
+          navigationButtonItemOptions={navigationButtonItemOptions}
+        />
+      </div>
+    )
   },
 }

--- a/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
@@ -1,4 +1,5 @@
 import type { ReactNode, type MouseEvent, ReactElement } from 'react'
+import { type ITourProps } from 'src/components'
 import { type HrefOptions } from 'src/utils/utils'
 import { type Icons } from 'src/constants/Icons'
 
@@ -48,7 +49,9 @@ export interface IMiniMapOptions {
   activeLink: MiniMapLinks
 }
 
-export interface INavSwitcherTourOptions {
+export interface INavSwitcherTourOptions extends ITourProps {
   isOpen: boolean
   onClose: () => void
+  title?: string
+  description?: string
 }

--- a/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
@@ -50,7 +50,7 @@ export interface IMiniMapOptions {
 }
 
 export interface INavSwitcherTourOptions extends ITourProps {
-  isOpen: boolean
+  open: boolean
   onClose: () => void
   title?: string
   description?: string

--- a/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigationItems.d.ts
@@ -14,6 +14,7 @@ export interface IGlobalNavigationLogo extends IBaseGlobalNavigationItem {
   onSuiteLogoClick: () => void
   type?: 'default' | 'background-solid' | 'custom-size'
   icon?: ReactElement | keyof typeof Icons
+  navSwitcherTourOptions?: INavSwitcherTourOptions
 }
 
 export interface IGlobalNavigationMenu extends IBaseGlobalNavigationItem {
@@ -45,4 +46,9 @@ export interface IMiniMapOptions {
   onUnauthorizedClick?: (link?: MiniMapLink) => void
   unauthorizedLinks?: MiniMapLinks[]
   activeLink: MiniMapLinks
+}
+
+export interface INavSwitcherTourOptions {
+  isOpen: boolean
+  onClose: () => void
 }

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -24,23 +24,11 @@ export function SuiteLogo({
 }: IGlobalNavigationLogo) {
   const logoRef = useRef(null)
 
-  const navSwitcherStep: ITourProps['steps'] = [
-    {
-      title: 'Navigate mParticle effortlessly!',
-      description: 'Switch between product suites anytime using this selector.',
-      placement: 'right',
-      target: () => logoRef.current,
-      nextButtonProps: {
-        children: 'Close',
-      },
-    },
-  ]
-
   return (
     <>
       <div ref={logoRef}>
         {renderNavLogo()}
-        {navSwitcherTourOptions && renderNavTour(navSwitcherStep, navSwitcherTourOptions)}
+        {navSwitcherTourOptions && renderNavTour(navSwitcherTourOptions)}
       </div>
     </>
   )
@@ -73,10 +61,26 @@ export function SuiteLogo({
     )
   }
 
-  function renderNavTour(steps: ITourProps['steps'], props: INavSwitcherTourOptions) {
+  function renderNavTour(props: INavSwitcherTourOptions) {
+    const DefaultTitle = 'Navigate mParticle effortlessly!' as const
+    const DefaultDescription = 'Switch between product suites anytime using this selector.' as const
+    const DefaultPlacement = 'right' as const
+
+    const navSwitcherStep: ITourProps['steps'] = [
+      {
+        title: DefaultTitle,
+        description: DefaultDescription,
+        placement: DefaultPlacement,
+        target: () => logoRef.current,
+        nextButtonProps: {
+          children: 'Close',
+        },
+      },
+    ]
+
     return (
       <>
-        <Tour mask={false} type="primary" steps={steps} open={props.isOpen} onClose={props.onClose} />
+        <Tour mask={false} type="primary" steps={navSwitcherStep} open={props.isOpen} onClose={props.onClose} />
       </>
     )
   }

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -1,9 +1,12 @@
-import React, { ReactElement, ReactNode } from 'react'
-import { Center, Icon } from 'src/components'
+import React, { type ReactNode, useRef } from 'react'
+import { Center, Icon, type ITourProps, Tour } from 'src/components'
 import { NavigationIcon } from 'src/components/navigation/GlobalNavigation/NavigationIcon'
-import { Icons } from 'src/constants/Icons'
-import { type IGlobalNavigationLogo } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
-import { IconColor } from 'src/components/general/Icon/Icon'
+import { type Icons } from 'src/constants/Icons'
+import {
+  type IGlobalNavigationLogo,
+  type INavSwitcherTourOptions,
+} from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
+import { type IconColor } from 'src/components/general/Icon/Icon'
 
 // custom-size is the default size to prevent breaking changes.
 type IconColorOptions = 'default' | 'background-solid' | 'custom-size'
@@ -12,30 +15,69 @@ function isStringIcon(icon: ReactNode | string): icon is keyof typeof Icons {
   return typeof icon === 'string'
 }
 
-export function SuiteLogo({ icon, label, type = 'custom-size', onSuiteLogoClick }: IGlobalNavigationLogo) {
-  const classMap = {
-    default: '',
-    'custom-size': 'globalNavigation__icon--suiteLogo',
-    'background-solid': 'globalNavigation__icon--suiteBackground',
-  }
+export function SuiteLogo({
+  icon,
+  label,
+  type = 'custom-size',
+  onSuiteLogoClick,
+  navSwitcherTourOptions,
+}: IGlobalNavigationLogo) {
+  const logoRef = useRef(null)
 
-  const iconColorMap: { [key in IconColorOptions]: IconColor } = {
-    default: 'default',
-    'background-solid': 'brand',
-    'custom-size': 'default',
-  }
-
-  const getIcon = () => {
-    if (isStringIcon(icon)) {
-      return <Icon name={icon} color={iconColorMap[type]} size="xl" />
-    }
-    return icon
-  }
+  const navSwitcherStep: ITourProps['steps'] = [
+    {
+      title: 'Navigate mParticle effortlessly!',
+      description: 'Switch between product suites anytime using this selector.',
+      placement: 'right',
+      target: () => logoRef.current,
+      nextButtonProps: {
+        children: 'Close',
+      },
+    },
+  ]
 
   return (
-    <Center vertical className="globalNavigation__suiteLogo" onClick={onSuiteLogoClick}>
-      <NavigationIcon icon={getIcon()} label="" hideLabel className={classMap[type]} />
-      {label}
-    </Center>
+    <>
+      <div ref={logoRef}>
+        {renderNavLogo()}
+        {navSwitcherTourOptions && renderNavTour(navSwitcherStep, navSwitcherTourOptions)}
+      </div>
+    </>
   )
+
+  function renderNavLogo() {
+    const classMap = {
+      default: '',
+      'custom-size': 'globalNavigation__icon--suiteLogo',
+      'background-solid': 'globalNavigation__icon--suiteBackground',
+    }
+
+    const iconColorMap: { [key in IconColorOptions]: IconColor } = {
+      default: 'default',
+      'background-solid': 'brand',
+      'custom-size': 'default',
+    }
+
+    const getIcon = () => {
+      if (isStringIcon(icon)) {
+        return <Icon name={icon} color={iconColorMap[type]} size="xl" />
+      }
+      return icon
+    }
+
+    return (
+      <Center vertical className="globalNavigation__suiteLogo" onClick={onSuiteLogoClick}>
+        <NavigationIcon icon={getIcon()} label="" hideLabel className={classMap[type]} />
+        {label}
+      </Center>
+    )
+  }
+
+  function renderNavTour(steps: ITourProps['steps'], props: INavSwitcherTourOptions) {
+    return (
+      <>
+        <Tour mask={false} type="primary" steps={steps} open={props.isOpen} onClose={props.onClose} />
+      </>
+    )
+  }
 }

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -68,8 +68,8 @@ export function SuiteLogo({
 
     const navSwitcherStep: ITourProps['steps'] = [
       {
-        title: DefaultTitle,
-        description: DefaultDescription,
+        title: props.title ?? DefaultTitle,
+        description: props.description ?? DefaultDescription,
         placement: DefaultPlacement,
         target: () => logoRef.current,
         nextButtonProps: {

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -80,7 +80,7 @@ export function SuiteLogo({
 
     return (
       <>
-        <Tour mask={false} type="primary" steps={navSwitcherStep} open={props.isOpen} onClose={props.onClose} />
+        <Tour mask={false} type="primary" steps={navSwitcherStep} {...props} />
       </>
     )
   }


### PR DESCRIPTION
## Summary

- Based on the user's request, we will move the nav switcher (minimap) to the top of the nav bar and open it on suite logo hover. To bring awareness to the change, we are adding a Tour component, to highlight the area of change. This PR contains the implementation of this component.

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Run the `MP With Nav Switcher Tour` story in GlobalNavigation. Clicking on the SuiteLogo to see the tour popup.
<img width="1235" alt="Screenshot 2024-08-12 at 3 32 17 PM" src="https://github.com/user-attachments/assets/aeaf868e-0396-4a44-855a-395d933ad57e">

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://mparticle-eng.atlassian.net/browse/UNI-881
