### PR TITLE
fix: add width auto to be able to manage the wdith from the component

### DIFF
--- a/src/components/data-display/Empty/Empty.stories.tsx
+++ b/src/components/data-display/Empty/Empty.stories.tsx
@@ -55,6 +55,7 @@ export const NoImage: Story = {
 export const AltImage: Story = {
   args: {
     image: Empty.PRESENTED_IMAGE_SIMPLE,
+    imageStyle: { width: '100px', height: '62px', margin: 'auto' },
   },
 }
 

--- a/src/components/data-display/Empty/Empty.tsx
+++ b/src/components/data-display/Empty/Empty.tsx
@@ -1,6 +1,7 @@
 import { Empty as AntEmpty } from 'antd'
 import { type EmptyProps as AntEmptyProps } from 'antd'
 import { ConfigProvider } from 'src/components'
+import './empty.css'
 
 export interface IEmptyProps extends AntEmptyProps {}
 

--- a/src/components/data-display/Empty/empty.css
+++ b/src/components/data-display/Empty/empty.css
@@ -1,0 +1,3 @@
+.ant-empty-image > svg{
+  width: auto !important;
+}


### PR DESCRIPTION
## Summary

- This PR adds the possibility to make the image of the Empty component bigger through props 

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
