### PR TITLE
feat: move minimap to suite logo

### DIFF
--- a/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -6,6 +6,7 @@ import { Badge } from 'src/components/data-display/Badge/Badge'
 import {
   type IGlobalNavigationItem,
   type IGlobalNavigationLogo,
+  type IMiniMapOptions,
 } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
 import { generateOrgs } from 'src/components/navigation/GlobalNavigation/stories-utils'
 import { type INavigationOrg } from 'src/components/navigation/GlobalNavigation/WorkspaceSelector/WorkspaceSelectorItems'
@@ -1207,6 +1208,26 @@ export const MPWithNavSwitcherTour: Story = {
       },
     }
 
+    const minimapOptions: IMiniMapOptions = {
+      overviewHref: '/',
+      onLinkClick: link => {
+        alert(link.href)
+      },
+      onUnauthorizedClick: link => {
+        alert(`unauthorized ${link?.href} `)
+      },
+      unauthorizedLinks: ['dataPlatform'],
+      activeLink: 'oversight',
+      links: [
+        { linkId: 'oversight', href: '/oversight' },
+        { linkId: 'dataPlatform', href: '/data-platform' },
+        { linkId: 'customer360', href: '/customer-360' },
+        { linkId: 'predictions', href: '/predictions' },
+        { linkId: 'analytics', href: '/analytics' },
+        { linkId: 'segmentation', href: '/segmentation' },
+      ],
+    }
+
     return (
       <div style={{ width: 800 }}>
         <GlobalNavigation
@@ -1221,6 +1242,7 @@ export const MPWithNavSwitcherTour: Story = {
             alert('going to overview map')
           }}
           navigationButtonItemOptions={navigationButtonItemOptions}
+          minimapOptions={minimapOptions}
         />
       </div>
     )

--- a/src/components/navigation/GlobalNavigation/GlobalNavigation.tsx
+++ b/src/components/navigation/GlobalNavigation/GlobalNavigation.tsx
@@ -53,7 +53,7 @@ export const GlobalNavigation = ({ showSuiteLogo = true, ...props }: IGlobalNavi
           <div>
             {showSuiteLogo && (
               <>
-                <SuiteLogo {...props.logo} />
+                <SuiteLogo {...props.logo} minimapOptions={props.minimapOptions} />
                 <div className="globalNavigation__divider" />
               </>
             )}
@@ -82,9 +82,7 @@ export const GlobalNavigation = ({ showSuiteLogo = true, ...props }: IGlobalNavi
                 />
               )
             )}
-            {!props.hideMpHome && (
-              <HomeButton onMpHomeClick={props.onMpHomeClick} minimapOptions={props.minimapOptions} />
-            )}
+            {!props.hideMpHome && <HomeButton onMpHomeClick={props.onMpHomeClick} />}
           </div>
         </Flex>
       </Layout.Sider>

--- a/src/components/navigation/GlobalNavigation/HomeButton.tsx
+++ b/src/components/navigation/GlobalNavigation/HomeButton.tsx
@@ -1,14 +1,8 @@
-import React, { useState } from 'react'
-import { Center, Icon, Popover, Tooltip } from 'src/components'
-import MiniMap from 'src/components/navigation/MiniMap/MiniMap'
-import { IMiniMapOptions, MiniMapLink } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
+import React from 'react'
+import { Center, Icon, Tooltip } from 'src/components'
 
 interface MpHomeButtonProps {
   onClick: () => void
-}
-
-interface MinimapWithPopoverProps extends IMiniMapOptions {
-  onPopoverClick: () => void
 }
 
 interface TooltipWithButtonProps {
@@ -16,7 +10,6 @@ interface TooltipWithButtonProps {
 }
 
 interface HomeButtonProps {
-  minimapOptions?: IMiniMapOptions
   onMpHomeClick: () => void
 }
 
@@ -25,37 +18,6 @@ function MpHomeButton(props: MpHomeButtonProps) {
     <Center className="globalNavigation__mpHome" onClick={props.onClick}>
       <Icon name="mpLogo" size="lg" color="white" />
     </Center>
-  )
-}
-
-function MinimapWithPopover(props: MinimapWithPopoverProps) {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-  const handleLinkClick = (link: MiniMapLink) => {
-    setIsPopoverOpen(false)
-    props.onLinkClick(link)
-  }
-  const handlePopoverOpenChange = (newPopoverState: boolean) => {
-    setIsPopoverOpen(newPopoverState)
-  }
-
-  return (
-    <Popover
-      content={
-        <MiniMap
-          overviewHref={props.overviewHref}
-          onUnauthorizedClick={props.onUnauthorizedClick}
-          links={props.links}
-          onLinkClick={handleLinkClick}
-          unauthorizedLinks={props.unauthorizedLinks}
-          activeLink={props.activeLink}
-        />
-      }
-      placement="rightBottom"
-      open={isPopoverOpen}
-      onOpenChange={handlePopoverOpenChange}
-      arrow={false}>
-      <MpHomeButton onClick={props.onPopoverClick} />
-    </Popover>
   )
 }
 
@@ -68,19 +30,5 @@ function TooltipWithButton(props: TooltipWithButtonProps) {
 }
 
 export function HomeButton(props: HomeButtonProps) {
-  if (!props.minimapOptions) {
-    return <TooltipWithButton onTooltipClick={props.onMpHomeClick} />
-  }
-
-  return (
-    <MinimapWithPopover
-      onUnauthorizedClick={props.minimapOptions.onUnauthorizedClick}
-      overviewHref={props.minimapOptions.overviewHref}
-      links={props.minimapOptions.links}
-      onLinkClick={props.minimapOptions.onLinkClick}
-      unauthorizedLinks={props.minimapOptions.unauthorizedLinks}
-      onPopoverClick={props.onMpHomeClick}
-      activeLink={props.minimapOptions.activeLink}
-    />
-  )
+  return <TooltipWithButton onTooltipClick={props.onMpHomeClick} />
 }

--- a/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteLogo.tsx
@@ -1,41 +1,104 @@
-import React, { ReactElement, ReactNode } from 'react'
-import { Center, Icon } from 'src/components'
+import React, { type ReactNode, useState } from 'react'
+import { Center, Icon, Popover } from 'src/components'
 import { NavigationIcon } from 'src/components/navigation/GlobalNavigation/NavigationIcon'
-import { Icons } from 'src/constants/Icons'
-import { type IGlobalNavigationLogo } from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
-import { IconColor } from 'src/components/general/Icon/Icon'
+import MiniMap from 'src/components/navigation/MiniMap/MiniMap'
+import { type Icons } from 'src/constants/Icons'
+import {
+  type IGlobalNavigationLogo,
+  type IMiniMapOptions,
+  type MiniMapLink,
+} from 'src/components/navigation/GlobalNavigation/GlobalNavigationItems'
+import { type IconColor } from 'src/components/general/Icon/Icon'
 
 // custom-size is the default size to prevent breaking changes.
 type IconColorOptions = 'default' | 'background-solid' | 'custom-size'
+
+interface SuiteLogoProps extends IGlobalNavigationLogo {
+  minimapOptions?: IMiniMapOptions
+}
 
 function isStringIcon(icon: ReactNode | string): icon is keyof typeof Icons {
   return typeof icon === 'string'
 }
 
-export function SuiteLogo({ icon, label, type = 'custom-size', onSuiteLogoClick }: IGlobalNavigationLogo) {
-  const classMap = {
-    default: '',
-    'custom-size': 'globalNavigation__icon--suiteLogo',
-    'background-solid': 'globalNavigation__icon--suiteBackground',
-  }
-
-  const iconColorMap: { [key in IconColorOptions]: IconColor } = {
-    default: 'default',
-    'background-solid': 'brand',
-    'custom-size': 'default',
-  }
-
-  const getIcon = () => {
-    if (isStringIcon(icon)) {
-      return <Icon name={icon} color={iconColorMap[type]} size="xl" />
-    }
-    return icon
+export function SuiteLogo({ icon, label, type = 'custom-size', onSuiteLogoClick, minimapOptions }: SuiteLogoProps) {
+  // TODO: || navSwitcherTourOptions?.isOpen
+  if (!minimapOptions) {
+    return <SuiteLogoContent />
   }
 
   return (
-    <Center vertical className="globalNavigation__suiteLogo" onClick={onSuiteLogoClick}>
-      <NavigationIcon icon={getIcon()} label="" hideLabel className={classMap[type]} />
-      {label}
-    </Center>
+    <MinimapWithPopover
+      onUnauthorizedClick={minimapOptions.onUnauthorizedClick}
+      overviewHref={minimapOptions.overviewHref}
+      links={minimapOptions.links}
+      onLinkClick={minimapOptions.onLinkClick}
+      unauthorizedLinks={minimapOptions.unauthorizedLinks}
+      activeLink={minimapOptions.activeLink}
+    />
   )
+
+  function SuiteLogoContent() {
+    return <>{renderNavLogo()}</>
+  }
+
+  function MinimapWithPopover(props: IMiniMapOptions) {
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+    const handleLinkClick = (link: MiniMapLink) => {
+      setIsPopoverOpen(false)
+      props.onLinkClick(link)
+    }
+    const handlePopoverOpenChange = (newPopoverState: boolean) => {
+      setIsPopoverOpen(newPopoverState)
+    }
+
+    return (
+      <Popover
+        content={
+          <MiniMap
+            overviewHref={props.overviewHref}
+            onUnauthorizedClick={props.onUnauthorizedClick}
+            links={props.links}
+            onLinkClick={handleLinkClick}
+            unauthorizedLinks={props.unauthorizedLinks}
+            activeLink={props.activeLink}
+          />
+        }
+        placement="bottomLeft"
+        open={isPopoverOpen}
+        trigger="hover"
+        onOpenChange={handlePopoverOpenChange}
+        arrow={false}>
+        <SuiteLogoContent />
+      </Popover>
+    )
+  }
+
+  function renderNavLogo() {
+    const classMap = {
+      default: '',
+      'custom-size': 'globalNavigation__icon--suiteLogo',
+      'background-solid': 'globalNavigation__icon--suiteBackground',
+    }
+
+    const iconColorMap: { [key in IconColorOptions]: IconColor } = {
+      default: 'default',
+      'background-solid': 'brand',
+      'custom-size': 'default',
+    }
+
+    const getIcon = () => {
+      if (isStringIcon(icon)) {
+        return <Icon name={icon} color={iconColorMap[type]} size="xl" />
+      }
+      return icon
+    }
+
+    return (
+      <Center vertical className="globalNavigation__suiteLogo" onClick={onSuiteLogoClick}>
+        <NavigationIcon icon={getIcon()} label="" hideLabel className={classMap[type]} />
+        {label}
+      </Center>
+    )
+  }
 }

--- a/src/components/navigation/MiniMap/MiniMap.tsx
+++ b/src/components/navigation/MiniMap/MiniMap.tsx
@@ -2,7 +2,6 @@ import 'src/styles/_variables.css'
 import './miniMap.css'
 import React from 'react'
 import { Button, ConfigProvider } from 'src/components'
-import Logo from 'src/assets/svg/mp-logo-wordmark.svg?react'
 import { minimap } from './minimap-svg'
 import { Flex } from 'src/components/layout/Flex/Flex'
 import { type ISvgLink, SvgLinker } from 'src/components/navigation/MiniMap/SvgLinker'
@@ -33,15 +32,14 @@ const Minimap = (props: IMiniMapProps) => {
 
   return (
     <ConfigProvider>
-      <div className="u-padding-sm">
+      <div className="u-padding-xxs">
         <Flex align="normal" component="div" flex="0 1 auto" gap="small" justify="stretch" vertical wrap="nowrap">
-          <Flex align="center" justify="space-between">
-            <Logo />
-            <Button href={props.overviewHref || '/'}>Go to overview</Button>
-          </Flex>
           <SvgLinker links={svgLinks} onLinkClick={handleLinkClick}>
             {minimap}
           </SvgLinker>
+          <Flex align="center" justify="end">
+            <Button href={props.overviewHref || '/'}>Go to overview</Button>
+          </Flex>
         </Flex>
       </div>
     </ConfigProvider>

--- a/src/utils/utils.css
+++ b/src/utils/utils.css
@@ -17,3 +17,7 @@
 .u-padding-sm {
   padding:var(--padding-sm) !important;
 }
+
+.u-padding-xxs {
+  padding: var(--padding-xxs) !important;
+}


### PR DESCRIPTION
## Summary

- Based on user feedback, it was decided to move the minimap to the top of the nav bar and open on suite logo hover. 
- Design spec: https://www.figma.com/design/Zua9XIORG5fXRnrs2FZkfJ/Overview-Map-post-GA-Improvements?node-id=5317-12165&m=dev
- **Important**: should only be merged after https://github.com/mParticle/aquarium/pull/367. 

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Run `Global Navigation` stories (mp or cortex) confirm minimap now opens on top nav logo hover.
- Run `Global Navigation: MP With Nav Switcher Tour` on Suite Logo hover you''ll get the minimap, on click the Tour popover.
<img width="664" alt="Screenshot 2024-08-13 at 3 10 54 PM" src="https://github.com/user-attachments/assets/2a81d4a1-356f-477d-9653-1d6787a30034">

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://mparticle-eng.atlassian.net/browse/UNI-880
