### PR TITLE
fix: improve workspace selector performace

### DIFF
--- a/src/components/navigation/GlobalNavigation/WorkspaceSelector/WorkspaceSelectorContentItems.tsx
+++ b/src/components/navigation/GlobalNavigation/WorkspaceSelector/WorkspaceSelectorContentItems.tsx
@@ -1,16 +1,23 @@
-import { type IWorkspaceSelectorDisplayItem } from 'src/components'
+import { type IWorkspaceSelectorDisplayItem, List } from 'src/components'
+import VirtualList from 'rc-virtual-list'
 
 type WorkspaceSelectorContentItemsProps = {
   menuItems: IWorkspaceSelectorDisplayItem[]
 }
+
+const CONTAINER_HEIGHT = 324
+const ITEM_HEIGHT = 20
+
 export function WorkspaceSelectorContentItems({ menuItems }: WorkspaceSelectorContentItemsProps) {
   return (
-    <ul className="workspaceSelector__itemsList">
-      {menuItems.map(item => (
-        <li key={item.key} className={item.className} onClick={item.onClick}>
-          {item.label}
-        </li>
-      ))}
-    </ul>
+    <List className="workspaceSelector__itemsList">
+      <VirtualList data={menuItems} height={CONTAINER_HEIGHT} itemHeight={ITEM_HEIGHT} itemKey="key">
+        {item => (
+          <li key={item.key} className={item.className} onClick={item.onClick}>
+            {item.label}
+          </li>
+        )}
+      </VirtualList>
+    </List>
   )
 }


### PR DESCRIPTION
## Summary
Some users have a long list of orgs/accounts/workspaces available, which was causing some slowness on this component, because it was rendering the whole list of items on every re-render.
This PR changes it to use virtualization, which means that it will render only the items visible to the user. 

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- used the `mp-thousand-orgs` test in storybook to confirm performace improvments
- validated no side effects on other use-cases

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/UNI-830
