### PR TITLE
fix: update nav link active background color

### DIFF
--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -125,7 +125,7 @@
 
 .globalNavigation__item.globalNavigation__item--active {
   border-left-color: var(--color-primary);
-  background-color: var(--color-bg-text-hover);
+  background-color: var(--control-item-bg-active);
 }
 
 .globalNavigation__search {
@@ -305,7 +305,7 @@
 .globalNavigation__icon.globalNavigation__icon--suiteLogo svg {
   width: 36px;
   height: 36px;
-  
+
 }
 
 .globalNavigation__divider {


### PR DESCRIPTION
## Summary

- We used the wrong color token for an active link in the nav bar, and with the recent tokens update it looks a bit odd. Thie PR brings an update to use the right color token.

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Open global nav stories. Confirm that the active link is using the correct background-color (`var(--control-item-bg-active)`)

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
