### PR TITLE
fix: unnest css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.30.1-fix-css-in-nancy.2](https://github.com/mParticle/aquarium/compare/v1.30.1-fix-css-in-nancy.1...v1.30.1-fix-css-in-nancy.2) (2024-09-04)
+
+### Bug Fixes
+
+- home logo svg unnested ([3eb695b](https://github.com/mParticle/aquarium/commit/3eb695bf73aca2a2e84f3601e0a6e96422750382))
+
 ## [1.30.1-fix-css-in-nancy.1](https://github.com/mParticle/aquarium/compare/v1.30.0...v1.30.1-fix-css-in-nancy.1) (2024-09-03)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.30.1-fix-css-in-nancy.1",
+  "version": "1.30.1-fix-css-in-nancy.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.30.1-fix-css-in-nancy.1",
+      "version": "1.30.1-fix-css-in-nancy.2",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.30.1-fix-css-in-nancy.1",
+  "version": "1.30.1-fix-css-in-nancy.2",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/components/navigation/GlobalNavigation/SuiteSelector/suite-selector.css
+++ b/src/components/navigation/GlobalNavigation/SuiteSelector/suite-selector.css
@@ -1,7 +1,3 @@
-:root {
-  --suite-selector-content-max-width: 272px;
-}
-
 .suiteSelector__content {
   max-width: var(--suite-selector-content-max-width);
   margin-bottom: var(--margin-xs);

--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -6,7 +6,8 @@
   --color-scrollbar-handle: rgb(0 0 0 / 15%);
   --color-scrollbar-track: transparent;
   --size-scrollbar-handle: 6px;
-  --label-size: 10px
+  --label-size: 10px;
+  --suite-selector-content-max-width: 272px;
 }
 
 .globalNavigation {

--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -325,9 +325,9 @@
   background-color: black;
   color: white;
   cursor: pointer;
+}
 
-  svg {
-    width: 28px;
-    height: var(--size-lg);
-  }
+.globalNavigation__mpHome svg {
+  width: 28px;
+  height: var(--size-lg);
 }

--- a/src/components/navigation/GlobalNavigation/global-navigation.css
+++ b/src/components/navigation/GlobalNavigation/global-navigation.css
@@ -302,10 +302,8 @@
   border-radius: 100%;
 }
 
-.globalNavigation__suiteLogo:hover .globalNavigation__icon--suiteBackground  {
-  svg {
-    fill: var(--mp-brand-primary-7);
-  }
+.globalNavigation__suiteLogo:hover .globalNavigation__icon--suiteBackground svg {
+  fill: var(--mp-brand-primary-7);
 }
 
 .globalNavigation__icon.globalNavigation__icon--suiteLogo svg {


### PR DESCRIPTION
## Summary

-Nesting css classes is not working properly in CDP production. This PR contains a fix to the nav logo and home logo in the global navigation to unnest the SVG and make them use proper styling in CDP production.

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- Tested with feature branch release in CDP PR env, and confirmed it worked.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes Part of: https://mparticle-eng.atlassian.net/browse/UNI-967
