### PR TITLE
fix: add horizontal gap in suite selector

### DIFF
--- a/src/components/navigation/GlobalNavigation/SuiteSelector/SuiteSelectorContent.tsx
+++ b/src/components/navigation/GlobalNavigation/SuiteSelector/SuiteSelectorContent.tsx
@@ -22,7 +22,7 @@ export function SuiteSelectorContent(props: ISuiteSelectorContentProps) {
   return (
     <>
       <div className="u-padding-xxs">
-        <Row gutter={[0, 4]} className="suiteSelector__content">
+        <Row gutter={[4, 4]} className="suiteSelector__content">
           {props.links.map(link => (
             <Col span={8} key={link.linkId}>
               <SuiteSelectorSuiteLink


### PR DESCRIPTION
## Summary

- Updating suite selector cards with horizontal gaps.
<img width="375" alt="Screenshot 2024-09-04 at 2 10 22 PM" src="https://github.com/user-attachments/assets/a4c707f8-80de-4b41-8d3b-7d6787b8b85e"> 

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Run global navigation stories. Confirm that the suite selector has a horizontal gap between links.
