### PR TITLE
fix: exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.33.1-fix-exported-types.1](https://github.com/mParticle/aquarium/compare/v1.33.0...v1.33.1-fix-exported-types.1) (2024-10-11)
+
+### Bug Fixes
+
+- fix issue on prettifier ([#446](https://github.com/mParticle/aquarium/issues/446)) ([03668b6](https://github.com/mParticle/aquarium/commit/03668b6743aafd4a2ae40ceeec1411792427e392))
+- update icons that did not obey the color prop ([#445](https://github.com/mParticle/aquarium/issues/445)) ([68006e3](https://github.com/mParticle/aquarium/commit/68006e36843ec2e9e367d225bd6d2080bc2fcc19))
+
 ## [1.33.1-chore-better-types-2.1](https://github.com/mParticle/aquarium/compare/v1.33.0...v1.33.1-chore-better-types-2.1) (2024-10-11)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.33.1-chore-better-types-2.1](https://github.com/mParticle/aquarium/compare/v1.33.0...v1.33.1-chore-better-types-2.1) (2024-10-11)
+
+### Bug Fixes
+
+- fix issue on prettifier ([#446](https://github.com/mParticle/aquarium/issues/446)) ([03668b6](https://github.com/mParticle/aquarium/commit/03668b6743aafd4a2ae40ceeec1411792427e392))
+- update icons that did not obey the color prop ([#445](https://github.com/mParticle/aquarium/issues/445)) ([68006e3](https://github.com/mParticle/aquarium/commit/68006e36843ec2e9e367d225bd6d2080bc2fcc19))
+
 # [1.33.0](https://github.com/mParticle/aquarium/compare/v1.32.0...v1.33.0) (2024-09-30)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.33.1-fix-exported-types.1](https://github.com/mParticle/aquarium/compare/v1.33.0...v1.33.1-fix-exported-types.1) (2024-10-11)
+
+### Bug Fixes
+
+- fix issue on prettifier ([#446](https://github.com/mParticle/aquarium/issues/446)) ([03668b6](https://github.com/mParticle/aquarium/commit/03668b6743aafd4a2ae40ceeec1411792427e392))
+- trying to include the src folder manually ([9549606](https://github.com/mParticle/aquarium/commit/9549606e0deb49e35cf9937215fdae8854f9cdcf))
+- update icons that did not obey the color prop ([#445](https://github.com/mParticle/aquarium/issues/445)) ([68006e3](https://github.com/mParticle/aquarium/commit/68006e36843ec2e9e367d225bd6d2080bc2fcc19))
+
 ## [1.33.1-fix-exported-types.2](https://github.com/mParticle/aquarium/compare/v1.33.1-fix-exported-types.1...v1.33.1-fix-exported-types.2) (2024-10-11)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.33.1-fix-exported-types.2](https://github.com/mParticle/aquarium/compare/v1.33.1-fix-exported-types.1...v1.33.1-fix-exported-types.2) (2024-10-11)
+
+### Bug Fixes
+
+- trying to include the src folder manually ([9549606](https://github.com/mParticle/aquarium/commit/9549606e0deb49e35cf9937215fdae8854f9cdcf))
+
 ## [1.33.1-fix-exported-types.1](https://github.com/mParticle/aquarium/compare/v1.33.0...v1.33.1-fix-exported-types.1) (2024-10-11)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-fix-exported-types.1",
+  "version": "1.33.1-fix-exported-types.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.33.1-fix-exported-types.1",
+      "version": "1.33.1-fix-exported-types.2",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-fix-exported-types.2",
+  "version": "1.33.1-fix-exported-types.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.33.1-fix-exported-types.2",
+      "version": "1.33.1-fix-exported-types.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.0",
+  "version": "1.33.1-chore-better-types-2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.33.0",
+      "version": "1.33.1-chore-better-types-2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-chore-better-types-2.1",
+  "version": "1.33.1-fix-exported-types.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "1.33.1-chore-better-types-2.1",
+      "version": "1.33.1-fix-exported-types.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
   "main": "dist/aquarium.umd.cjs",
   "module": "dist/aquarium.js",
   "files": [
-    "dist"
+    "dist/aquarium.umd.cjs",
+    "dist/aquarium.js",
+    "dist/index.d.ts",
+    "dist/style.css",
+    "dist/style.ts",
+    "dist/src"
   ],
   "peerDependencies": {
     "antd": ">=5.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-fix-exported-types.1",
+  "version": "1.33.1-fix-exported-types.2",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.0",
+  "version": "1.33.1-chore-better-types-2.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-fix-exported-types.2",
+  "version": "1.33.1-fix-exported-types.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "1.33.1-chore-better-types-2.1",
+  "version": "1.33.1-fix-exported-types.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,11 +17,7 @@
   "main": "dist/aquarium.umd.cjs",
   "module": "dist/aquarium.js",
   "files": [
-    "dist/aquarium.umd.cjs",
-    "dist/aquarium.js",
-    "dist/index.d.ts",
-    "dist/style.css",
-    "dist/style.ts"
+    "dist"
   ],
   "peerDependencies": {
     "antd": ">=5.20.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
 
-  plugins: [svgr(), dts({ include: 'src/components', rollupTypes: true })],
+  plugins: [svgr(), dts({ include: 'src/', exclude: '**/*.stories.*', rollupTypes: false, insertTypesEntry: true })],
 
   build: {
     target: 'es6',


### PR DESCRIPTION
## Summary

This PR changes the build for Aquarium to preserve the file structure for types and thus fixing the exported types that were not correct.

## Testing Plan

- [X] Was this tested locally? If not, explain why.

Tested this using the link process, now need to debug why semantic-release is failing to release a version for us to test in the platforms

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/UNI-153
