### PR TITLE
fix: (styles) remove shadow of the buttons and update suite selector hover

### DIFF
--- a/design/LightTheme.ts
+++ b/design/LightTheme.ts
@@ -108,9 +108,6 @@ export const LightTheme: IMpThemeConfig = {
     },
     Button: {
       borderColorDisabled: '#dcdcd8',
-      primaryShadow: '0 2px 0 rgba(44, 0, 170, 0.4)',
-      defaultShadow: '0 2px 0 rgba(44, 0, 170, 0.2)',
-      dangerShadow: '0 2px 0 rgba(44, 0, 170, 0.3)',
     },
     Input: {
       activeShadow: '0 0 0 2px rgba(54, 0, 209, 0.1)',

--- a/design/MpThemeConfig.d.ts
+++ b/design/MpThemeConfig.d.ts
@@ -70,9 +70,6 @@ export type IMpThemeConfig = ThemeConfig & {
     }
     Button: {
       borderColorDisabled: string
-      primaryShadow: string
-      defaultShadow: string
-      dangerShadow: string
     }
     Input: {
       activeShadow: string

--- a/src/components/navigation/GlobalNavigation/SuiteSelector/suite-selector.css
+++ b/src/components/navigation/GlobalNavigation/SuiteSelector/suite-selector.css
@@ -18,7 +18,7 @@
 }
 
 .suiteSelector__link:not(.suiteSelector__link--active, .suiteSelector__link--disabled):hover .suiteSelector__suiteLogo {
-  background-color: var(--control-item-bg-hover);
+  background-color: var(--color-white);
 }
 
 .suiteSelector__link.suiteSelector__link--active {


### PR DESCRIPTION
## Summary

This PR updates the hover state of the suite selector to white upon discussion with design:

<img width="302" alt="Screenshot 2024-10-17 at 4 48 35 PM" src="https://github.com/user-attachments/assets/a6df7d9a-07a7-4817-84b5-2a3dc06a11a8">

and removes the shadow added on the Aqua 1.33.0

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
