### PR TITLE
docs: ability to assign badges to stories and dropdown as an example

### DIFF
--- a/.storybook/manager.css
+++ b/.storybook/manager.css
@@ -1,0 +1,15 @@
+.componentTag__container--beta {
+  position: static;
+}
+
+.componentTag__badge--beta {
+  font-size: 12px;
+  font-weight: 500;
+  margin-top: -13px;
+  padding: 0 6px;
+  background-color: #faad14;
+}
+
+.componentTag__badge--beta > .ant-ribbon-corner {
+  color: #faad14;
+}

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,6 +1,0 @@
-import { addons } from '@storybook/manager-api'
-import customTheme from './theme'
-
-addons.setConfig({
-  theme: customTheme,
-})

--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { addons } from '@storybook/manager-api'
+import customTheme from './theme'
+import { Badge } from 'antd'
+
+import './manager.css'
+
+addons.setConfig({
+  theme: customTheme,
+  sidebar: {
+    renderLabel: item => {
+      if (item.tags?.includes('deprecated')) {
+        return (
+          <div title={item.name}>
+            <span>{item.name}</span>
+            <Badge.Ribbon
+              rootClassName="componentTag__container--beta"
+              className="componentTag__badge--beta"
+              text="Deprecated"
+            />
+          </div>
+        )
+      }
+
+      return item.name
+    },
+  },
+})

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -52,8 +52,6 @@ const preview: Preview = {
       },
     },
   },
-
-  tags: ['autodocs'],
 }
 
 export default preview

--- a/src/components/navigation/Dropdown/Dropdown.stories.tsx
+++ b/src/components/navigation/Dropdown/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
-import { type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { cloneElement } from 'react'
 import { useState } from 'react'
-import { type Meta, type StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from 'src/components/general/Button/Button'
 import { Dropdown, type IDropdownProps } from 'src/components/navigation/Dropdown/Dropdown'
 import { ExampleStory } from 'src/utils/ExampleStory'
@@ -9,7 +9,7 @@ import { Tooltip, type IMenuProps, Icon } from 'src/components'
 import { Space } from 'src/components'
 import { Divider } from 'src/components'
 import { theme } from 'antd'
-import { type MenuProps } from 'antd'
+import type { MenuProps } from 'antd'
 import { Typography } from 'src/components/general/Typography/Typography'
 
 const menu: IDropdownProps['menu'] = {
@@ -93,7 +93,9 @@ type Story = StoryObj<typeof Dropdown>
   Customize the stories based on specific requirements.
 */
 
-export const Primary: Story = {}
+export const Primary: Story = {
+  tags: ['deprecated'],
+}
 
 export const WithArrow: Story = {
   args: {


### PR DESCRIPTION
## Summary

- Ability to assign Badge.Ribbon to component stories via tags based on [shilman/storybook-tag-badges](https://github.com/shilman/storybook-tag-badges). Not definitive where we are going to use this yet but design requested the ability to be able to do so.
- Also tried [@geometricpanda/storybook-addon-badges](https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges) but couldn't make it work as expected.

![image](https://github.com/user-attachments/assets/4431e51b-96d9-4143-8e9f-f4da5bee56fe)

## Testing Plan

- [X] Was this tested locally? If not, explain why.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/UNI-1073
