### PR TITLE
fix: (styles) update font weight of modal

### DIFF
--- a/src/components/feedback/Modal/modal.css
+++ b/src/components/feedback/Modal/modal.css
@@ -1,3 +1,8 @@
+.ant-modal p,
+.ant-modal span {
+    font-weight: 400;
+}
+
 .ant-modal .ant-modal-title {
     font-weight: var(--font-weight-strong)
 }


### PR DESCRIPTION
## Summary

This PR adds styles of the modal back to fix this issue:

![image](https://github.com/user-attachments/assets/23627ed5-c9b9-4f99-b39f-07921d386c9f)

with the fix:
<img width="726" alt="Screenshot 2024-11-04 at 11 23 24 AM" src="https://github.com/user-attachments/assets/af9ccf10-fe99-4038-bde2-3f3756ac9359">

## Testing Plan

- [x] Was this tested locally? If not, explain why.

I built aquarium locally and tested it in Nancy

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
