### PR TITLE
feat: popupMatchSelectWidth should default to false

### DIFF
--- a/src/components/data-entry/Select/Select.tsx
+++ b/src/components/data-entry/Select/Select.tsx
@@ -19,7 +19,7 @@ export const Select = <
 ) => {
   return (
     <ConfigProvider>
-      <AntSelect suffixIcon={<Icon name="dropdownOpen" size="sm" />} {...props} />
+      <AntSelect popupMatchSelectWidth={false} suffixIcon={<Icon name="dropdownOpen" size="sm" />} {...props} />
     </ConfigProvider>
   )
 }


### PR DESCRIPTION
## Instructions

## Summary

- I posit that this is the better default. I was recently working in an area and it was hidden to me (and I almost shipped a bug) that a certain select items were being truncated. 
- This does not prevent the user from overwriting the supplied value, it's just a better default (imo)

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
