### PR TITLE
docs: documentation pages now appear first when clicking a story

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,17 +1,12 @@
 import type { Preview } from '@storybook/react'
-// import type { IndexEntry } from '@storybook/types'
 
 const preview: Preview = {
   parameters: {
     layout: 'centered',
     options: {
-      // TODO https://mparticle-eng.atlassian.net/browse/UNI-1214
-      // storySort: (a: IndexEntry, b: IndexEntry) => {
-      // console.log('Ordering stories', { a, b })
-      // const order = ['Documentation', 'Cell Types', 'Filters', 'Primary', 'Complex']
-      // return order.indexOf(a[1].name) - order.indexOf(b[1].name)
-      // },
       storySort: {
+        method: 'alphabetical',
+        includeNames: true,
         order: [
           'About',
           ['Introduction', 'Changelog', 'Feedback', 'Component Process'],
@@ -21,7 +16,9 @@ const preview: Preview = {
           [
             'Data Display',
             'Data Entry',
+            ['QueryItem', ['Documentation']],
             'General',
+            ['Button', ['Documentation']],
             'Feedback',
             'Layout',
             'Navigation',

--- a/docs/components/Data Display/Badge/Documentation.mdx
+++ b/docs/components/Data Display/Badge/Documentation.mdx
@@ -10,10 +10,9 @@ import * as BadgeStories from '../../../../src/components/data-display/Badge/Bad
 
 #### Overview
 
-The **Badge** component provides visual indicators for an item’s status, available in two styles: a **dot** and a **status badge" with text.
+The **Badge** component provides visual indicators for an item’s status, available in two styles: a **dot** and a \*\*status badge" with text.
 
 ### [Dot Badge](https://mparticle.github.io/aquarium/?path=/story/components-data-display-badge--dot-badge)
-
 
 #### When to use
 
@@ -37,10 +36,9 @@ For displaying status with accompanying text (e.g., "Active," "Failed," or "Draf
 
 #### Related Links
 
-| Type  | Resource                                                                                                                                               |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Type  | Resource                                                                                                                                                          |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Eames | [Badge Component](https://www.figma.com/design/veXnmignQnJz8StIq10VJ5/Eames-2.0---Foundations-%26-Components?node-id=399-0&node-type=canvas&t=B6HJWqqDsUOypZQj-0) |
-| AntD | [Badge Component](https://ant.design/components/badge) |
+| AntD  | [Badge Component](https://ant.design/components/badge)                                                                                                            |
 
-
-<Canvas of={BadgeStories.BadgeStatus} />
+<Canvas of={BadgeStories.StatusBadge} />

--- a/src/components/data-display/Badge/Badge.stories.tsx
+++ b/src/components/data-display/Badge/Badge.stories.tsx
@@ -24,7 +24,7 @@ export const DotBadge: Story = {
   },
 }
 
-export const BadgeStatus: Story = {
+export const StatusBadge: Story = {
   argTypes: {
     status: {
       control: 'select',

--- a/src/components/data-entry/DatePicker/DatePicker.stories.tsx
+++ b/src/components/data-entry/DatePicker/DatePicker.stories.tsx
@@ -62,11 +62,11 @@ type Story = StoryObj<typeof DatePicker>
 
 export const Primary: Story = {}
 
-export const WithDatePickerWithDisabledYears: Story = {
+export const WithDisabledYears: Story = {
   render: () => <DatePickerWithDisabledYears />,
 }
 
-WithDatePickerWithDisabledYears.parameters = {
+WithDisabledYears.parameters = {
   docs: {
     source: {
       code: `


### PR DESCRIPTION
## Summary

The goal of this PR is to make our `Documentation` pages be the first ones in the list so that when a user clicks in a Story it goes directly to them instead of an example story. Storybook 7 provides 2 ways of sorting stories: 1. providing a nested `options.storySort.order` array containing stories titles in sorted order or 2. providing an `options.storySort` function that acts as a standard sort function (receives 2 stories, returns 1, 0, -1). 

I went down the rabbit hole of implementing our own sorting function because I couldn't figure it out why our documentation pages were not being considered until I've stumbled upon `options.storySort.includeNames` option which defaults to `false`. Default here means actual story names ("Documentation") were not included for sorting and storybook only sorted by the higher level titles ("Components/Data Display/Avatar"). Turning this option `true` means now all story names are included ("Components/Data Display/Avatar/StoryName") up to the lowest level and we can then include them in our nested order array. This includes the documentation pages and we can now sort them however we want.

Also if we don't provide any sorting things are sorted alphabetically which just so happens to put the Documentation page as the first one mostly everywhere. 

## Testing Plan

- [X] Was this tested locally? If not, explain why.

Go over the PR env and make sure the Documentation pages are listed first under our components and they are navigated to when clicking in a Story.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- Closes https://go.mparticle.com/work/UNI-1214
