### PR TITLE
refactor: update typography style prop passing

### DIFF
--- a/src/components/general/Typography/Text.stories.tsx
+++ b/src/components/general/Typography/Text.stories.tsx
@@ -3,6 +3,7 @@ import type { StoryObj } from '@storybook/react'
 import { Space } from 'src/components'
 import { Switch } from 'src/components'
 import { Typography } from 'src/components/general/Typography/Typography'
+import { PaddingLg } from 'src/styles/style'
 import { ExampleStory } from 'src/utils/ExampleStory'
 import { useState } from 'react'
 import { expect } from '@storybook/test'
@@ -102,6 +103,20 @@ export const ExampleTexts: Story = {
           <Typography.Text delete>Aquarium (delete)</Typography.Text>
           <Typography.Text strong>Aquarium (strong)</Typography.Text>
           <Typography.Text italic>Aquarium (italic)</Typography.Text>
+        </Space>
+      </ExampleStory>
+    )
+  },
+}
+
+export const ExampleProps: Story = {
+  render: () => {
+    return (
+      <ExampleStory title={<> </>}>
+        <Space direction="vertical">
+          <Typography.Text size="sm" color="ColorPrimaryText" style={{ paddingLeft: PaddingLg }}>
+            Aquarium props test
+          </Typography.Text>
         </Space>
       </ExampleStory>
     )

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -74,7 +74,7 @@ const Text = (props: ITextProps) => {
 Typography.Text = Text
 
 const Title = (props: ITitleProps) => {
-  const { size, color, type, children, ...rest } = props
+  const { size, color, type, children, style, ...rest } = props
 
   const fontSize = size ? getFontSize(size) : undefined
   const lineHeight = size ? getLineHeight(size) : undefined
@@ -82,7 +82,7 @@ const Title = (props: ITitleProps) => {
 
   return (
     <ConfigProvider>
-      <AntTypography.Title style={{ color: fontColor, fontSize, lineHeight, ...props.style }} type={type} {...rest}>
+      <AntTypography.Title style={{ color: fontColor, fontSize, lineHeight, ...style }} type={type} {...rest}>
         {children}
       </AntTypography.Title>
     </ConfigProvider>
@@ -92,7 +92,7 @@ const Title = (props: ITitleProps) => {
 Typography.Title = Title
 
 const Link = (props: ILinkProps) => {
-  const { size, color, type, tooltip, underline, children, ...rest } = props
+  const { size, color, type, tooltip, underline, children, style, ...rest } = props
 
   const fontSize = size ? getFontSize(size) : undefined
   const lineHeight = size ? getLineHeight(size) : undefined
@@ -101,7 +101,7 @@ const Link = (props: ILinkProps) => {
   return (
     <ConfigProvider>
       <AntTypography.Link
-        style={{ color: fontColor, fontSize, lineHeight, ...props.style }}
+        style={{ color: fontColor, fontSize, lineHeight, ...style }}
         type={type}
         underline={tooltip ?? underline}
         {...rest}>
@@ -114,7 +114,7 @@ const Link = (props: ILinkProps) => {
 Typography.Link = Link
 
 const Paragraph = (props: IParagraphProps) => {
-  const { size, color, type, children, ...rest } = props
+  const { size, color, type, children, style, ...rest } = props
 
   const fontSize = size ? getFontSize(size) : undefined
   const lineHeight = size ? getLineHeight(size) : undefined
@@ -122,7 +122,7 @@ const Paragraph = (props: IParagraphProps) => {
 
   return (
     <ConfigProvider>
-      <AntTypography.Paragraph style={{ color: fontColor, fontSize, lineHeight, ...props.style }} type={type} {...rest}>
+      <AntTypography.Paragraph style={{ color: fontColor, fontSize, lineHeight, ...style }} type={type} {...rest}>
         {children}
       </AntTypography.Paragraph>
     </ConfigProvider>

--- a/src/components/general/Typography/Typography.tsx
+++ b/src/components/general/Typography/Typography.tsx
@@ -56,7 +56,7 @@ export interface IParagraphProps extends InternalParagraphProps {}
 
 // Tried generalizing into a higher order component but couldn't do it type-safely, so just repeated the code
 const Text = (props: ITextProps) => {
-  const { size, color, type, tooltip, children, ...rest } = props
+  const { size, color, type, tooltip, children, style, ...rest } = props
 
   const fontSize = size ? getFontSize(size) : undefined
   const lineHeight = size ? getLineHeight(size) : undefined
@@ -64,7 +64,7 @@ const Text = (props: ITextProps) => {
 
   return (
     <ConfigProvider>
-      <AntTypography.Text style={{ color: fontColor, fontSize, lineHeight, ...props.style }} type={type} {...rest}>
+      <AntTypography.Text style={{ color: fontColor, fontSize, lineHeight, ...style }} type={type} {...rest}>
         {children}
       </AntTypography.Text>
     </ConfigProvider>


### PR DESCRIPTION
## Instructions
## Summary

- @leobel discovered an issue with passing passing `size`, `color`  and `style` props to typography components, the style is overriding the size and color. This PR brings a fix to the typography components style prop passing.

## Testing Plan

- [x] Was this tested locally? If not, explain why.
- Run Text: Example Props story
<img width="1281" alt="Screenshot 2025-02-11 at 3 16 29 PM" src="https://github.com/user-attachments/assets/876c94d9-87be-44f0-b878-c09248f4678e" />

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)

- Closes https://go.mparticle.com/work/REPLACEME
