### PR TITLE
chore: add aquarium 2 skill files

### DIFF
--- a/.claude/output/skills/aquarium-docs-v2.md
+++ b/.claude/output/skills/aquarium-docs-v2.md
@@ -1,0 +1,176 @@
+---
+name: aquarium-docs
+description: Look up Aquarium and Ant Design component APIs, props, and usage examples. Use when someone asks how a component works, what props it accepts, or needs a usage example. Triggers on aquarium docs, component API, how does component work, what props, usage example, Flex props, Table columns, Modal confirm, Form validation, Select options, mparticle aquarium, antd component help.
+---
+
+# Aquarium Docs Lookup
+
+On-demand component API reference. Fetches from Aquarium Storybook and Ant Design docs to answer "how does this component work?" and "which component should I use?"
+
+## Core Principles
+
+**Aquarium Storybook is primary**: Shows Aquarium-specific props, customizations, and visual demos. Check here first.
+**Ant Design docs are secondary**: Complete API reference for the underlying component. Use when Storybook lacks detail.
+**Always import from Aquarium**: Even when referencing Ant Design docs, all code examples must use `@mparticle/aquarium` imports — never `antd` directly.
+**Aquarium 2 uses antd v6 + React 19**: Be aware of breaking changes from v5 (see migration section).
+
+## Execution
+
+### Step 1: Identify the component and category
+
+| Category         | Components                                                                                                                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **General**      | Button, FloatButton, Icon, Typography                                                                                                                                        |
+| **Layout**       | Flex, Space, Divider, Row, Col, Layout, Splitter                                                                                                                             |
+| **Navigation**   | Menu, Breadcrumb, Dropdown, Pagination, Steps, Tabs, GlobalNavigation                                                                                                        |
+| **Data Entry**   | Form, Input, InputNumber, Select, TreeSelect, Checkbox, Radio, Switch, Slider, DatePicker, TimePicker, Transfer, Upload, AutoComplete, ColorPicker, Rate, Cascader, Mentions |
+| **Data Display** | Table, Card, Collapse, List, Descriptions, Popover, Tooltip, Tag, Badge, Avatar, Calendar, Carousel, Image, Statistic, Timeline, Tree, Segmented, QRCode, Tour               |
+| **Feedback**     | Alert, Modal, Drawer, Notification, Message, Popconfirm, Progress, Result, Skeleton, Spin, Empty, Watermark                                                                  |
+| **UX Patterns**  | MoreActionsButton, StatisticsCard, NavigationBar, EmptyState, StatusIcon                                                                                                     |
+
+### Step 2: Fetch documentation
+
+**Aquarium Storybook** (primary):
+
+```
+https://mparticle.github.io/aquarium/?path=/docs/components-<category>-<component>--documentation
+```
+
+URL examples:
+
+- Button → `components-general-button--documentation`
+- Table → `components-data-display-table--documentation`
+- Modal → `components-feedback-modal--documentation`
+- Select → `components-data-entry-select--documentation`
+- Flex → `components-layout-flex--documentation`
+
+**Ant Design 6 docs** (secondary):
+
+```
+https://ant.design/components/<component-lowercase>
+```
+
+**Preferred**: Use `WebFetch` to pull from both sources. Prioritize Aquarium-specific information.
+
+**Fallback** (if WebFetch unavailable): Use Ant Design knowledge but clearly state it may not reflect Aquarium-specific customizations. Always include the Storybook and Ant Design URLs for manual verification.
+
+### Step 3: Present the answer
+
+```
+## <ComponentName>
+
+<One sentence description>
+
+### Key Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+
+### Aquarium-Specific
+- <Custom props or behavior differences from base Ant Design>
+
+### Example
+\`\`\`tsx
+import { ComponentName } from '@mparticle/aquarium'
+
+<ComponentName prop="value">
+  ...
+</ComponentName>
+\`\`\`
+
+### Gotchas
+- <Common mistakes>
+
+### Docs
+- Aquarium: <storybook-url>
+- Ant Design: <antd-url>
+```
+
+## Aquarium 2 Breaking Changes (antd v5 → v6)
+
+When providing examples, always use the current API. These v5 patterns are removed:
+
+| Old (v5)                            | New (v6)                                               | Component     |
+| ----------------------------------- | ------------------------------------------------------ | ------------- |
+| `dotPosition`                       | `dotPlacement` (values `left`/`right` → `start`/`end`) | Carousel      |
+| `labelPlacement`                    | `titlePlacement`                                       | Steps         |
+| `<Dropdown.Button>`                 | `<Space.Compact>` + `<Button>` + `<Dropdown>`          | Dropdown      |
+| `<FloatButton.BackTop>`             | Removed — use `FloatButton` with scroll listener       | FloatButton   |
+| `Space direction`                   | `Space orientation`                                    | Space         |
+| `Space split`                       | `Space separator`                                      | Space         |
+| `Divider type`                      | `Divider orientation`                                  | Divider       |
+| `Modal/Drawer visible`              | `Modal/Drawer open`                                    | Modal, Drawer |
+| `Table.Column fixed="left"/"right"` | `fixed="start"/"end"`                                  | Table         |
+| `Button iconPosition`               | `Button iconPlacement`                                 | Button        |
+
+## React 19 Patterns
+
+All Aquarium code and example code should follow React 19:
+
+- No `React.forwardRef` — accept `ref` as a plain prop
+- No `propTypes` — use TypeScript interfaces
+- No `defaultProps` on function components — use default parameter values
+- `useActionState` (not deprecated `useFormState`)
+
+## Common Patterns
+
+**"Which component should I use?"** — map UI patterns to components:
+
+| UI pattern                  | Component                                                       |
+| --------------------------- | --------------------------------------------------------------- |
+| Confirmation before action  | `Popconfirm` (inline) or `Modal.confirm()` (dialog)             |
+| Form with validation        | `Form` + `Form.Item` with `rules`                               |
+| Searchable dropdown         | `Select` with `showSearch`                                      |
+| Multi-select tags           | `Select` with `mode="multiple"`                                 |
+| Data table with sort/filter | `Table` with `columns` config                                   |
+| Expandable sections         | `Collapse`                                                      |
+| Step-by-step wizard         | `Steps` + conditional content                                   |
+| Toast notification          | `message.success()` (brief) or `notification.open()` (detailed) |
+| Inline editable text        | `Typography.Paragraph` with `editable`                          |
+| Loading skeleton            | `Skeleton` (layout) or `Spin` (action)                          |
+| Empty state                 | `Empty` or Aquarium's `EmptyState`                              |
+| Side panel                  | `Drawer`                                                        |
+| Overflow action menu        | `MoreActionsButton` (Aquarium UX Pattern)                       |
+| Status indicator            | `Badge` or `StatusIcon` (Aquarium UX Pattern)                   |
+| Key-value display           | `Descriptions`                                                  |
+| Split layout panes          | `Splitter` (new in antd v6)                                     |
+| Timeline / activity log     | `Timeline`                                                      |
+| Tree hierarchy              | `Tree` or `TreeSelect`                                          |
+| Button + dropdown combo     | `Space.Compact` + `Button` + `Dropdown` (not `Dropdown.Button`) |
+
+**Component not in Aquarium?**: Say so explicitly. Suggest requesting it be added rather than importing from `antd` directly.
+
+**Aquarium props naming**: Props interfaces use `I` prefix: `IButtonProps`, `IModalProps`, `ITableProps`. Types are exported alongside components.
+
+**Token import** (for consuming apps):
+
+```tsx
+import { ColorPrimary, PaddingLg, MarginMd } from '@mparticle/aquarium/dist/style'
+```
+
+**Compound components**: Always document sub-components:
+
+- `Form.Item`, `Form.List`, `Form.useForm`, `Form.useWatch`
+- `Input.Search`, `Input.Password`, `Input.TextArea`, `Input.OTP`
+- `Modal.confirm`, `Modal.info`, `Modal.success`, `Modal.warning`
+- `Typography.Title`, `Typography.Text`, `Typography.Paragraph`, `Typography.Link`
+- `Card.Meta`, `Card.Grid`
+- `Space.Compact` (replaces `Dropdown.Button`)
+- `Splitter.Panel`
+
+## Success Criteria
+
+- [ ] Correct component identified for the user's use case
+- [ ] Props table includes commonly used props with types
+- [ ] Code example uses `@mparticle/aquarium` imports (never `antd`)
+- [ ] antd v6 API used (not deprecated v5 patterns)
+- [ ] Aquarium-specific differences from Ant Design highlighted
+- [ ] Links to both Storybook and Ant Design 6 docs provided
+
+## Self-Improvement
+
+**Update triggers**:
+
+- New components added to Aquarium — update category table
+- Aquarium version upgrade — review migration tables
+- New compound components discovered — add to compound components list
+- Common "which component" questions not in the pattern table — add them

--- a/.claude/output/skills/aquarium-guardian-v2.md
+++ b/.claude/output/skills/aquarium-guardian-v2.md
@@ -1,0 +1,287 @@
+---
+name: aquarium-guardian
+description: Proactively enforces correct Aquarium usage in consuming apps. Catches direct antd imports, raw HTML instead of Aquarium layout components, style overrides, icon library misuse, and component duplication. Flags violations for maintainer review. Triggers on aquarium, antd import, component library, design system, Flex, Space, Button, Modal, Table, Form, Icon, mparticle, style override, div flex, ant-design.
+---
+
+# Aquarium Guardian
+
+Runs proactively while writing or editing code in any app that consumes `@mparticle/aquarium`. Catches violations in real time — before they reach a PR.
+
+## Core Principles
+
+**Aquarium wraps Ant Design 6**: Every Aquarium component applies a `ConfigProvider` for consistent theming. Importing from `antd` directly bypasses this and creates visual inconsistencies.
+**Components over raw HTML**: Aquarium provides layout and UI primitives. Recreating them with `<div>` and inline styles defeats the purpose.
+**Tokens over hardcoded values**: All colors, spacing, and sizing should reference Aquarium design tokens so themes stay consistent.
+
+## Violation Severity Levels
+
+**FIX**: Stop and correct immediately. Explain what was wrong and why.
+**WARN**: Pause and ask the user before proceeding. Present options.
+**FLAG**: Note silently. Surface as a summary at commit/PR time.
+
+## Execution
+
+### Step 1: Detect violations while writing code
+
+Scan every import statement, JSX element, and style declaration for violations as you write or edit files.
+
+### Step 2: Apply the correct severity response
+
+**FIX violations** — correct immediately:
+
+- Direct `antd` imports when `@mparticle/aquarium` is in dependencies
+- Direct `@ant-design/icons` or `react-icons` imports
+- Raw HTML replicating Aquarium components (see substitution table)
+- Custom components duplicating existing Aquarium functionality
+- Deprecated Ant Design 6 APIs (see Ant6 migration table)
+- Deprecated React 19 patterns (see React 19 migration table)
+
+**WARN violations** — ask before proceeding:
+
+- `style` prop overriding Aquarium component visual properties (background, color, border, font)
+- `className` adding visual overrides (not layout/positioning)
+- CSS files targeting `.ant-` class selectors
+- Hardcoded color/spacing/font values instead of design tokens
+
+**Allowed without warning**:
+
+- `style={{ width, height, maxWidth, minWidth, maxHeight, minHeight }}` — sizing
+- `style={{ margin*, position, top, left, right, bottom, zIndex }}` — layout positioning
+- `className` for layout/positioning only
+
+**FLAG violations** — collect for PR summary:
+
+- Any `.ant-` class selectors in CSS files
+- 3+ WARN violations in a single PR
+- `// aquarium-override` comments being added
+- Aquarium version changes in package.json
+
+### Step 3: Handle WARN confirmations
+
+When user confirms a style override, add a tracking comment:
+
+```tsx
+// aquarium-override: <user's reason>
+<Button style={{ backgroundColor: '#custom' }}>
+```
+
+### Step 4: Surface summary at commit/PR time
+
+```
+## Aquarium Violation Summary
+
+### Violations found: N
+
+1. **FIX** `path/file.tsx:12` — Direct antd import: `import { Table } from 'antd'`
+2. **WARN** `path/file.tsx:45` — Style override on `<Card>`: custom backgroundColor
+3. **FLAG** `path/file.css:8` — CSS targeting `.ant-card-body`
+
+### Recommendation
+→ Add an Aquarium maintainer as a reviewer for Aquarium compliance.
+```
+
+## Common Patterns
+
+**Direct antd import**:
+
+```tsx
+// FIX
+import { Button } from 'antd'
+import type { ButtonProps } from 'antd'
+
+// CORRECT
+import { Button } from '@mparticle/aquarium'
+import type { IButtonProps } from '@mparticle/aquarium'
+```
+
+**Raw HTML instead of Aquarium components**:
+
+| Instead of                                                   | Use                                           |
+| ------------------------------------------------------------ | --------------------------------------------- |
+| `<div style={{ display: 'flex' }}>`                          | `<Flex>`                                      |
+| `<div style={{ display: 'flex', flexDirection: 'column' }}>` | `<Flex vertical>`                             |
+| `<div>` with spacing styles                                  | `<Space>` or `<Flex>` with `gap`              |
+| `<h1>`, `<h2>`, `<p>`, `<span>` with styles                  | `<Typography.Title>`, `<Typography.Text>`     |
+| `<a href>` styled as button                                  | `<Button type="link">` or `<Typography.Link>` |
+| `<hr>`                                                       | `<Divider>`                                   |
+| `<table>`                                                    | `<Table>`                                     |
+| Raw `<input>`, `<select>`, `<textarea>`                      | `<Input>`, `<Select>`, `<Input.TextArea>`     |
+| Custom spinner                                               | `<Spin>`                                      |
+| Custom alert/banner                                          | `<Alert>`                                     |
+| Custom modal/dialog                                          | `<Modal>`                                     |
+| Custom tooltip                                               | `<Tooltip>`                                   |
+| Custom empty state                                           | `<Empty>` or `<EmptyState>`                   |
+| `window.confirm()`                                           | `Modal.confirm()` or `<Popconfirm>`           |
+
+**Exception**: Plain `<div>` used as a wrapper for positioning, refs, portals, or test-id containers is fine.
+
+**Icon imports**:
+
+```tsx
+// FIX
+import { FiSearch } from 'react-icons/fi'
+import { SearchOutlined } from '@ant-design/icons'
+
+// CORRECT — string-based mParticle SVG icons
+import { Icon } from '@mparticle/aquarium'
+;<Icon name="search" size="sm" />
+
+// CORRECT — Rokt/Untitled UI component icons
+import { Icon, RoktPauseCircle } from '@mparticle/aquarium'
+;<Icon name={RoktPauseCircle} size="sm" />
+```
+
+**Design tokens**:
+
+```tsx
+// WARN — hardcoded values
+style={{ color: '#6E56CF', padding: '24px' }}
+
+// FIX — wrong import path
+import { ColorPrimary } from '@mparticle/aquarium'
+
+// CORRECT — import from dist/style
+import { ColorPrimary, PaddingLg } from '@mparticle/aquarium/dist/style'
+style={{ color: ColorPrimary, padding: PaddingLg }}
+```
+
+**Token-to-property mapping**:
+
+| CSS property               | Token prefix    | Example                                         |
+| -------------------------- | --------------- | ----------------------------------------------- |
+| `padding`                  | `Padding*`      | `PaddingXs`, `PaddingSm`, `PaddingLg`           |
+| `margin`                   | `Margin*`       | `MarginXs`, `MarginSm`, `MarginLg`              |
+| `gap`, `width`, `height`   | `Size*`         | `SizeSm`, `SizeMd`, `SizeXl`                    |
+| `color`, `backgroundColor` | `Color*`        | `ColorPrimary`, `ColorText`, `ColorBgContainer` |
+| `fontSize`                 | `FontSize*`     | `FontSize`, `FontSizeSM`, `FontSizeLG`          |
+| `borderRadius`             | `BorderRadius*` | `BorderRadiusSm`, `BorderRadiusLG`              |
+
+**Note**: `MpBrand*` tokens are deprecated. Use semantic `Color*` tokens instead.
+
+## Ant Design 6 Migration — FIX Violations
+
+Aquarium 2 requires Ant Design 6. These v5 APIs are removed/renamed:
+
+| Old (antd v5)                          | New (antd v6)                                                   | Severity |
+| -------------------------------------- | --------------------------------------------------------------- | -------- |
+| `Carousel dotPosition`                 | `Carousel dotPlacement` — values `left`/`right` → `start`/`end` | FIX      |
+| `Steps labelPlacement`                 | `Steps titlePlacement`                                          | FIX      |
+| `<Dropdown.Button>`                    | `<Space.Compact>` + `<Button>` + `<Dropdown>`                   | FIX      |
+| `<FloatButton.BackTop>`                | Removed — implement with `FloatButton` + scroll listener        | FIX      |
+| `Space direction`                      | `Space orientation`                                             | FIX      |
+| `Space split`                          | `Space separator`                                               | FIX      |
+| `Divider type`                         | `Divider orientation`                                           | FIX      |
+| `Table.pagination.position`            | `Table.pagination.placement`                                    | FIX      |
+| `Progress gapPosition`                 | `Progress gapPlacement`                                         | FIX      |
+| `Timeline.items.position`              | `Timeline.items.placement`                                      | FIX      |
+| `Collapse expandIconPosition`          | `Collapse expandIconPlacement`                                  | FIX      |
+| `Button iconPosition`                  | `Button iconPlacement`                                          | FIX      |
+| `Table.Column fixed="left"/"right"`    | `fixed="start"/"end"`                                           | FIX      |
+| `<Modal visible>` / `<Drawer visible>` | `<Modal open>` / `<Drawer open>`                                | FIX      |
+
+**Dropdown.Button migration**:
+
+```tsx
+// FIX — Dropdown.Button removed in antd v6
+;<Dropdown.Button menu={menuProps}>Click me</Dropdown.Button>
+
+// CORRECT
+import { Space } from '@mparticle/aquarium'
+;<Space.Compact>
+  <Button>Click me</Button>
+  <Dropdown menu={menuProps}>
+    <Button icon={<Icon name={RoktChevronDown} />} />
+  </Dropdown>
+</Space.Compact>
+```
+
+## React 19 Migration — FIX Violations
+
+Aquarium 2 uses React 19. These patterns are deprecated/removed:
+
+| Pattern                                                 | Fix                             | Severity |
+| ------------------------------------------------------- | ------------------------------- | -------- |
+| `React.forwardRef(Component)`                           | Accept `ref` as a regular prop  | FIX      |
+| `Component.propTypes = {...}`                           | Use TypeScript interface        | FIX      |
+| `Component.defaultProps = {...}` on function components | Use default parameter values    | FIX      |
+| `import { useFormState } from 'react-dom'`              | `useActionState` from `'react'` | FIX      |
+
+**forwardRef migration**:
+
+```tsx
+// FIX — forwardRef deprecated in React 19
+const MyComponent = React.forwardRef<HTMLDivElement, IMyProps>((props, ref) => {
+  return <div ref={ref} {...props} />
+})
+
+// CORRECT — ref is a plain prop in React 19
+function MyComponent({ ref, ...props }: IMyProps & { ref?: React.Ref<HTMLDivElement> }) {
+  return <div ref={ref} {...props} />
+}
+```
+
+## Component API Gotchas
+
+**Modal/Drawer**: Use `open` prop, not `visible` (removed in antd v6):
+
+```tsx
+// FIX
+<Modal visible={isOpen}>
+
+// CORRECT
+<Modal open={isOpen}>
+```
+
+**Button loading**: When `loading={true}`, also set `disabled={true}`:
+
+```tsx
+// WARN — allows clicks while loading
+<Button loading={isSubmitting}>Submit</Button>
+
+// CORRECT
+<Button loading={isSubmitting} disabled={isSubmitting}>Submit</Button>
+```
+
+**Typography**: Never use raw `<span>`, `<p>`, `<h1>`–`<h6>` for text display. Use `Typography.Text`, `Typography.Title`, `Typography.Paragraph`.
+
+**Component duplication**:
+
+```tsx
+// FIX — Aquarium already has this
+const ConfirmDialog = ({ title, onOk, onCancel }) => <div className="overlay">...</div>
+
+// CORRECT
+Modal.confirm({ title, onOk, onCancel })
+```
+
+## Available Aquarium Components
+
+**General**: Button, FloatButton, Icon, Typography (Title, Text, Paragraph, Link)
+**Layout**: Flex, Space, Divider, Row, Col, Layout (Header, Content, Footer, Sider)
+**Navigation**: Menu, Breadcrumb, Dropdown, Pagination, Steps, Tabs, GlobalNavigation
+**Data Entry**: Form, Input, InputNumber, Select, TreeSelect, Checkbox, Radio, Switch, Slider, DatePicker, TimePicker, Transfer, Upload, AutoComplete, ColorPicker, Rate, Cascader
+**Data Display**: Table, Card, Collapse, List, Descriptions, Popover, Tooltip, Tag, Badge, Avatar, Calendar, Carousel, Image, Statistic, Timeline, Tree, Segmented, QRCode
+**Feedback**: Alert, Modal, Drawer, Notification, Message, Popconfirm, Progress, Result, Skeleton, Spin, Empty, Watermark
+**UX Patterns**: MoreActionsButton, StatisticsCard, NavigationBar, EmptyState, StatusIcon
+
+**Component not in Aquarium?** Suggest requesting it be added to Aquarium rather than importing from `antd` directly.
+
+**Not sure how a component works?** Use `/aquarium-docs` to look up props, usage examples, and gotchas.
+
+## Success Criteria
+
+- [ ] No direct `antd` or `@ant-design/icons` imports in changed files
+- [ ] No raw HTML replicating Aquarium components
+- [ ] All style overrides have `// aquarium-override: <reason>` comments
+- [ ] Hardcoded values replaced with design tokens
+- [ ] No deprecated antd v5 APIs
+- [ ] No deprecated React 19 patterns (`forwardRef`, `propTypes`, `defaultProps`)
+- [ ] Violation summary presented before commit/PR
+
+## Self-Improvement
+
+**Update triggers**:
+
+- New components added to Aquarium — update Available Components list
+- Aquarium version bump in consuming app — re-check migration tables
+- New common anti-patterns discovered during PR reviews — add to FIX list

--- a/.claude/skills/add-aquarium-component/SKILL.md
+++ b/.claude/skills/add-aquarium-component/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: add-aquarium-component
+description: Scaffold a new Aquarium component with all required files following Aquarium 2 conventions (Ant Design 6, React 19, Storybook 10). Generates the component, Storybook story with interaction tests, MDX docs stub, and wires up the export chain. Triggers on add component, new component, scaffold component, create component, aquarium component.
+group: aquarium
+---
+
+# Add Aquarium Component
+
+Scaffold a production-ready Aquarium component following all Aquarium 2 conventions.
+
+## What This Skill Does
+
+Creates all required files and wires them into the export chain:
+
+1. `src/components/<category>/<Name>/<Name>.tsx` — wraps antd, custom props interface
+2. `src/components/<category>/<Name>/<Name>.stories.tsx` — Storybook 10 with interaction tests
+3. `docs/components/<Category>/<Name>/Documentation.mdx` — MDX doc stub
+4. Updates `src/components/index.ts` — adds named export
+
+## Conversation Flow
+
+### Step 1: Gather requirements
+
+Ask the user:
+
+- Component name (PascalCase, e.g. `Tooltip`, `StatusCard`)
+- Category: `general` | `layout` | `navigation` | `data-entry` | `data-display` | `feedback` | `UXPatterns` | `not-prod-ready`
+- Which antd component it wraps (if any) — e.g. "wraps `Tooltip` from `antd`"
+- Key custom props to add beyond antd's interface
+
+### Step 2: Check for conflicts
+
+Before generating:
+
+- Search `src/components/index.ts` for an existing export with that name
+- Check if the category folder already has a matching subfolder
+- If conflict found, surface it and ask how to proceed
+
+### Step 3: Generate files
+
+#### Component file (`<Name>.tsx`)
+
+```tsx
+import React from 'react'
+import { <AntName> as Ant<Name>, type <AntName>Props as Ant<Name>Props } from 'antd'
+
+export interface I<Name>Props extends Ant<Name>Props {
+  // custom props here
+}
+
+export const <Name> = (props: I<Name>Props) => {
+  return <Ant<Name> {...props} />
+}
+```
+
+**React 19 rules (enforce strictly):**
+
+- NO `React.forwardRef` — accept `ref` as a plain prop: `({ ref, ...props }: I<Name>Props & { ref?: React.Ref<HTMLElement> })`
+- NO `propTypes` — TypeScript interfaces only
+- NO `defaultProps` — use default parameter values in destructuring
+- Import React only when JSX is used (React 19 doesn't require it but Aquarium style includes it)
+
+**Ant Design 6 rules:**
+
+- Wrap with `ConfigProvider` only if the component requires theme token overrides (check existing components)
+- Use `open` not `visible` for overlay/modal components
+- `dotPlacement` not `dotPosition` (Carousel)
+- `titlePlacement` not `labelPlacement` (Steps)
+- No `Dropdown.Button` — use `Space.Compact` + `Button` + `Dropdown`
+- No `FloatButton.BackTop` — use `FloatButton` with scroll-to-top logic
+
+**Props interface rules:**
+
+- Always `I` prefix: `IButtonProps`, `IModalProps`, `ITooltipProps`
+- Extend the antd props type: `extends AntTooltipProps`
+- Export both the component AND the interface
+
+#### Story file (`<Name>.stories.tsx`)
+
+```tsx
+import { <Name> } from 'src/components/<category>/<Name>/<Name>'
+import { type Meta, type StoryObj } from '@storybook/react'
+import React from 'react'
+
+const meta: Meta<typeof <Name>> = {
+  title: 'Components/<StorybookCategory>/<Name>',
+  component: <Name>,
+  args: {
+    // sensible defaults matching antd defaults
+  },
+  argTypes: {
+    // control types for interactive props
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof <Name>>
+
+export const Default: Story = {}
+
+export const Interactive: Story = {
+  play: async ({ canvasElement }) => {
+    // use @storybook/test utilities for interaction tests
+    // import { within, userEvent, expect } from 'storybook/test'
+  },
+}
+```
+
+**Storybook 10 rules:**
+
+- Import from `storybook/test` (not `@storybook/testing-library`)
+- Use `userEvent` from `storybook/test`
+- Title format: `'Components/<Category>/<Name>'` matching the folder structure
+- Always include a `Default` story and at least one story with a `play` function for key interactions
+
+#### Storybook category → title mapping:
+
+| Folder           | Storybook title segment |
+| ---------------- | ----------------------- |
+| `general`        | `General`               |
+| `layout`         | `Layout`                |
+| `navigation`     | `Navigation`            |
+| `data-entry`     | `Data Entry`            |
+| `data-display`   | `Data Display`          |
+| `feedback`       | `Feedback`              |
+| `UXPatterns`     | `UX Patterns`           |
+| `not-prod-ready` | `Not Prod Ready`        |
+
+#### MDX docs stub
+
+```mdx
+import { Meta, Canvas, Controls } from '@storybook/blocks'
+import * as <Name>Stories from './<Name>.stories'
+
+<Meta of={<Name>Stories} />
+
+# <Name>
+
+<one-line description of what the component does>
+
+## Usage
+
+<Canvas of={<Name>Stories.Default} />
+<Controls />
+
+## When to Use
+
+- <use case 1>
+- <use case 2>
+
+## Props
+
+<Controls />
+```
+
+Place at: `docs/components/<TitleCase Category>/<Name>/Documentation.mdx`
+
+#### Export chain update
+
+Add to `src/components/index.ts` (maintain alphabetical order within section):
+
+```ts
+export { <Name>, type I<Name>Props } from './<category>/<Name>/<Name>'
+```
+
+### Step 4: Verify
+
+Run after generating:
+
+```
+npm run build
+```
+
+Flag any TypeScript errors. Do not skip — type safety is non-negotiable.
+
+## Success Criteria
+
+- [ ] Component renders without errors in Storybook
+- [ ] No `antd` types leaked into the public API without explicit re-export
+- [ ] `npm run build` passes with zero errors
+- [ ] At least one `play` function story tests a user interaction
+- [ ] Export visible in `src/components/index.ts`
+- [ ] No `forwardRef`, `propTypes`, or `defaultProps` on function components
+- [ ] All hardcoded values use tokens from `src/styles/style`
+
+## Design Token Reference
+
+Import inside the Aquarium repo:
+
+```ts
+import { ColorPrimary, PaddingLg, MarginMd, SizeSm, BorderRadiusLg } from 'src/styles/style'
+```
+
+| CSS property               | Token prefix    | Examples                                        |
+| -------------------------- | --------------- | ----------------------------------------------- |
+| `padding`                  | `Padding*`      | `PaddingXs`, `PaddingSm`, `PaddingLg`           |
+| `margin`                   | `Margin*`       | `MarginXs`, `MarginSm`, `MarginLg`              |
+| `gap`, `width`, `height`   | `Size*`         | `SizeSm`, `SizeMd`, `SizeXl`                    |
+| `color`, `backgroundColor` | `Color*`        | `ColorPrimary`, `ColorText`, `ColorBgContainer` |
+| `fontSize`                 | `FontSize*`     | `FontSize`, `FontSizeSM`, `FontSizeLG`          |
+| `borderRadius`             | `BorderRadius*` | `BorderRadiusSm`, `BorderRadiusLG`              |

--- a/.claude/skills/storybook-play-tests/SKILL.md
+++ b/.claude/skills/storybook-play-tests/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: storybook-play-tests
+description: Generate Storybook play tests for Aquarium components. Covers user interactions, portal-aware Ant Design queries, and async assertions. Use for add play test, write play test, generate play test, interaction test, story testing, user event testing. Triggers on play test, storybook test, interaction test, story interaction, component test.
+group: storybook
+---
+
+# Storybook Play Tests — Aquarium
+
+Generate reliable interaction tests for Aquarium component stories using Storybook 10 + React 19 patterns.
+
+## When to Use
+
+- "Add play tests to this story"
+- "Write interaction tests for this component"
+- Adding or updating `.stories.tsx` files with interaction requirements
+
+**Not for:**
+
+- Standalone Vitest unit tests — Aquarium doesn't use per-component spec files
+- Non-interactive stories (visual-only)
+
+## Aquarium Environment
+
+- **Storybook**: 10.2.0
+- **Test runner**: `@storybook/test-runner` 0.24.2
+- **React**: 19
+- **Components**: Wrap Ant Design 6 — many elements render in portals
+
+## Story Structure
+
+```tsx
+import { type Meta, type StoryObj } from '@storybook/react'
+import { expect, screen, userEvent, within } from 'storybook/test'
+import { ComponentName } from 'src/components'
+
+const meta: Meta<typeof ComponentName> = {
+  title: 'Components/<Category>/<Name>',
+  tags: ['play-test-validation'],
+  component: ComponentName,
+  args: {
+    /* defaults */
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof ComponentName>
+
+export const StoryName: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Arrange — query elements
+    const input = canvas.getByRole('combobox')
+
+    // Act — interact
+    await userEvent.type(input, 'search term')
+
+    // Assert — verify (use waitFor for async)
+    const option = await screen.findByText('Expected Option')
+    await expect(option).toBeInTheDocument()
+  },
+}
+```
+
+## Import — CRITICAL
+
+```tsx
+// CORRECT — Aquarium uses this path
+import { expect, screen, userEvent, within } from 'storybook/test'
+
+// WRONG — do not use
+import { expect, userEvent } from '@storybook/test'
+```
+
+## Selector Hierarchy
+
+Since Aquarium wraps Ant Design, most elements don't have `data-testid`. Use semantic queries:
+
+1. **`getByRole()`** — primary choice for interactive elements
+2. **`getByLabelText()`** — for labelled form inputs
+3. **`getByPlaceholderText()`** — for inputs with placeholder
+4. **`screen.findByText()`** — for portal-rendered content (dropdowns, menus)
+5. **`querySelector('.ant-*')`** — last resort for Ant Design internals with no semantic selector
+
+Never reach for `data-testid` unless you're adding it to a custom Aquarium component that has no semantic query.
+
+## Ant Design Portal Pattern
+
+Ant Design Select, Dropdown, and similar components render their options **outside the component tree** in a document-level portal. Always use `screen` (not `canvas`) for these:
+
+```tsx
+// Select / AutoComplete / Dropdown options — use screen, not canvas
+play: async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+
+  // Open the dropdown (click the ant-select wrapper)
+  const selectEl = canvasElement.querySelector('.ant-select')!
+  await userEvent.click(selectEl)
+
+  // Options are in a portal — use screen.findByText
+  const option = await screen.findByText('Prod')
+  await expect(option).toBeInTheDocument()
+  await userEvent.click(option)
+},
+```
+
+For `AutoComplete`:
+
+```tsx
+const input = canvas.getByRole('combobox')
+await userEvent.type(input, 'quick')
+const option = await screen.findByText('The quick brown fox...')
+await userEvent.click(option)
+```
+
+## Tags
+
+Add `tags: ['play-test-validation']` to the `meta` object when adding play tests to a story file. Not all existing stories have this yet — add it when you touch a file:
+
+```tsx
+const meta: Meta<typeof Select> = {
+  title: 'Components/Data Entry/Select',
+  tags: ['play-test-validation'],
+  component: Select,
+  ...
+}
+```
+
+## Story Title Format
+
+Match the folder structure exactly:
+
+| Component folder  | Story title                                     |
+| ----------------- | ----------------------------------------------- |
+| `general/`        | `'Components/General/<Name>'`                   |
+| `layout/`         | `'Components/Layout/<Name>'`                    |
+| `navigation/`     | `'Components/Navigation/<Name>'`                |
+| `data-entry/`     | `'Components/Data Entry/<Name>'`                |
+| `data-display/`   | `'Components/Data Display/<Name>'`              |
+| `feedback/`       | `'Components/Feedback/<Name>'`                  |
+| `UXPatterns/`     | `'Components/UX Patterns/<Name>'`               |
+| `not-prod-ready/` | `'Components/Not Prod Ready/<Category>/<Name>'` |
+
+## DO NOT Use
+
+- `userEvent.setup()` — not needed in Aquarium stories
+- `PointerEventsCheckLevel` — not used here
+- `step()` function — Aquarium stories use flat AAA, not step blocks
+- `createStorybookForm` decorator — not in this codebase
+
+## Async Assertions
+
+```tsx
+// Async DOM changes — use findBy* (includes built-in wait)
+const el = await canvas.findByRole('button', { name: 'Submit' })
+
+// State changes after interaction — use waitFor
+await waitFor(() => expect(canvas.getByText('Success')).toBeInTheDocument())
+```
+
+Import `waitFor` from `storybook/test` if needed.
+
+## Running Tests
+
+```bash
+npm run test-storybook           # requires Storybook running on :6006
+npm run test-storybook:ci        # builds + serves + runs (CI mode)
+```
+
+## Coverage Per Component Type
+
+| Component type       | Minimum coverage                            |
+| -------------------- | ------------------------------------------- |
+| Simple toggle/button | Default state + click interaction           |
+| Input / form field   | Type input + validation feedback            |
+| Select / dropdown    | Open + option select + value reflected      |
+| Multi-step / wizard  | Each step transition + final submission     |
+| Async (data loading) | Loading state + success state + error state |
+
+## Output Format
+
+Deliver the complete updated `.stories.tsx` file with:
+
+- `tags: ['play-test-validation']` added to meta
+- All necessary imports from `storybook/test`
+- `play` functions using inline AAA pattern (no `step()` blocks)
+- Portal-aware queries (`screen` for dropdowns, `canvas` for everything else)


### PR DESCRIPTION
## Summary
- Skill files extracted from aquarium-2-final PR for isolated merge
- `add-aquarium-component` — scaffold new components (Ant6 + React19 + SB10)
- `storybook-play-tests` — generate Storybook interaction play tests
- `aquarium-docs-v2` and `aquarium-guardian-v2` skill output docs