### PR TITLE
feat: add RoktRocket and RoktUsers icons

### DIFF
--- a/docs/Foundations/Icons/Rokt Icons.mdx
+++ b/docs/Foundations/Icons/Rokt Icons.mdx
@@ -62,6 +62,8 @@ import {
   RoktGitMerge,
   RoktGitCommit,
   RoktGitPullRequest,
+  RoktRocket,
+  RoktUsers,
 } from '../../../src/components/icons'
 
 # Rokt Icons
@@ -321,5 +323,13 @@ import {
   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
     <Icon name={RoktGitPullRequest} size="sm" color="black" />
     <p style={{ fontFamily: 'monospace', fontSize: '12px', textAlign: 'center', margin: 0, wordBreak: 'break-word' }}>RoktGitPullRequest</p>
+  </div>
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
+    <Icon name={RoktRocket} size="sm" color="black" />
+    <p style={{ fontFamily: 'monospace', fontSize: '12px', textAlign: 'center', margin: 0, wordBreak: 'break-word' }}>RoktRocket</p>
+  </div>
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '8px' }}>
+    <Icon name={RoktUsers} size="sm" color="black" />
+    <p style={{ fontFamily: 'monospace', fontSize: '12px', textAlign: 'center', margin: 0, wordBreak: 'break-word' }}>RoktUsers</p>
   </div>
 </div>

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -205,6 +205,8 @@ import {
   GitMerge as RoktGitMerge,
   GitCommit as RoktGitCommit,
   GitPullRequest as RoktGitPullRequest,
+  Rocket02 as RoktRocket,
+  Users01 as RoktUsers,
 } from '@untitledui/icons'
 
 export {
@@ -413,4 +415,6 @@ export {
   RoktGitMerge,
   RoktGitCommit,
   RoktGitPullRequest,
+  RoktRocket,
+  RoktUsers,
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -230,4 +230,6 @@ export {
   RoktGitMerge,
   RoktGitCommit,
   RoktGitPullRequest,
+  RoktRocket,
+  RoktUsers,
 } from './icons'


### PR DESCRIPTION
## Summary

- Registers `Rocket02` from `@untitledui/icons` as `RoktRocket`
- Registers `Users01` from `@untitledui/icons` as `RoktUsers`
- Exports both from `src/components/index.ts`
- Adds both to the Rokt Icons documentation page

These icons are needed by the catalog-frontend repo for the Campaigns create flow (grow sales and acquisition objective cards).

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- Build verified locally with `npm run build` — no errors
- Icons visible in `docs/Foundations/Icons/Rokt Icons.mdx` documentation grid