### PR TITLE
fix: update RadioCard intro link to point to documentation page

### DIFF
--- a/docs/About/componentCategories.json
+++ b/docs/About/componentCategories.json
@@ -146,7 +146,7 @@
         {
           "name": "RadioCard",
           "variantCount": 1,
-          "storyId": "components-data-entry-radio-card--vertical"
+          "storyId": "components-data-entry-radiocard--documentation"
         },
         {
           "name": "Select",


### PR DESCRIPTION
## Summary
- Update RadioCard `storyId` in `componentCategories.json` to point to the documentation page instead of a removed story
- Old path `components-data-entry-radio-card--vertical` no longer exists after RadioCard stories were tagged `!dev`

## Test plan
- [ ] Open Storybook Introduction page
- [ ] Click RadioCard in the component grid
- [ ] Verify it navigates to the RadioCard Documentation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)