### PR TITLE
feat: add GitHub issue templates, ADOPTING.md, and rebrand to Rokt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,70 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug in an Aquarium component
+labels: ['bug']
+body:
+  - type: input
+    id: component
+    attributes:
+      label: Component
+      description: Which component is affected?
+      placeholder: e.g., Select, Table, DatePicker
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Aquarium Version
+      description: Which version of @mparticle/aquarium are you using?
+      placeholder: e.g., 2.2.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What happened? What did you expect to happen?
+      placeholder: |
+        **What happened:** The Select dropdown doesn't close when clicking outside.
+        **Expected:** It should close on outside click, matching standard Ant Design behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Render a `<Select>` with `mode="multiple"`
+        2. Open the dropdown
+        3. Click outside the component
+        4. Observe the dropdown stays open
+    validations:
+      required: true
+
+  - type: input
+    id: storybook-link
+    attributes:
+      label: Storybook Link (if applicable)
+      description: Link to the relevant Storybook story
+      placeholder: https://mparticle.github.io/aquarium/?path=/story/...
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Recordings
+      description: Drag and drop any screenshots or screen recordings here
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - 'Low — cosmetic issue'
+        - 'Medium — workaround available'
+        - 'High — broken functionality, no workaround'
+        - 'Critical — blocks production'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/component-request.yml
+++ b/.github/ISSUE_TEMPLATE/component-request.yml
@@ -1,0 +1,91 @@
+name: "\U0001F9E9 Component Request"
+description: Request a new component or a significant enhancement to an existing one
+labels: ['component-request', 'enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Request a Component
+
+        Before submitting, please check:
+        - [Storybook](https://mparticle.github.io/aquarium/) — does a similar component already exist?
+        - [Ant Design](https://ant.design/components/overview/) — can an existing Ant Design component be configured for your use case?
+
+  - type: input
+    id: component-name
+    attributes:
+      label: Component Name
+      description: What should this component be called?
+      placeholder: e.g., DataGrid, StatusBadge, FilterBar
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: What problem does this component solve? Which product(s) need it?
+      placeholder: |
+        We need a filterable data grid for the Audiences page in [product].
+        Currently we're using a raw antd Table with custom filter logic duplicated across 3 views.
+    validations:
+      required: true
+
+  - type: input
+    id: figma-link
+    attributes:
+      label: Figma Link
+      description: Link to the Figma design (if available)
+      placeholder: https://www.figma.com/design/...
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgently does your team need this?
+      options:
+        - 'Nice to have — no deadline'
+        - 'Upcoming sprint — needed within 2 weeks'
+        - "Blocking — can't ship without it"
+    validations:
+      required: true
+
+  - type: input
+    id: team
+    attributes:
+      label: Team / Product
+      description: Which team or product is requesting this?
+      placeholder: e.g., Audiences, Connections, Data Platform
+    validations:
+      required: true
+
+  - type: textarea
+    id: existing-workaround
+    attributes:
+      label: Current Workaround
+      description: How are you solving this today? (raw antd, custom code, another library?)
+      placeholder: We're importing directly from antd and wrapping it in a custom component in our repo.
+
+  - type: textarea
+    id: api-sketch
+    attributes:
+      label: Proposed API (optional)
+      description: If you have ideas on the component API, sketch it here
+      placeholder: |
+        <DataGrid
+          columns={columns}
+          dataSource={data}
+          filterable
+          sortable
+          onFilterChange={handleFilter}
+        />
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I've checked that no existing Aquarium component covers this use case
+          required: true
+        - label: I've checked that this can't be achieved by configuring an existing Ant Design component
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Aquarium Weekly Updates
+    url: https://chat.google.com/room/AAQADRm8Au8?cls=7
+    about: Join the Aquarium GChat space for weekly updates and discussions
+  - name: Storybook Documentation
+    url: https://mparticle.github.io/aquarium/
+    about: Browse available components and their documentation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Aquarium Weekly Updates
-    url: https://chat.google.com/room/AAQADRm8Au8?cls=7
-    about: Join the Aquarium GChat space for weekly updates and discussions
   - name: Storybook Documentation
     url: https://mparticle.github.io/aquarium/
     about: Browse available components and their documentation

--- a/.github/ISSUE_TEMPLATE/general-question.yml
+++ b/.github/ISSUE_TEMPLATE/general-question.yml
@@ -1,0 +1,42 @@
+name: "\U00002753 Question / Discussion"
+description: Ask a question about Aquarium usage, patterns, or adoption
+labels: ['question']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Question or Discussion
+
+        For quick questions, you can also reach us in the [Aquarium GChat space](https://chat.google.com/room/AAQADRm8Au8?cls=7).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+      placeholder: |
+        How should I handle custom theming when my product uses a different primary color?
+        Is there a recommended pattern for form validation with Aquarium components?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - 'How to use a component'
+        - 'Migration from raw antd to Aquarium'
+        - 'Design tokens / theming'
+        - 'Setting up Aquarium in a new project'
+        - 'AI tooling integration (Claude Code, Cursor, etc.)'
+        - 'Other'
+    validations:
+      required: true
+
+  - type: input
+    id: team
+    attributes:
+      label: Team / Product (optional)
+      description: Which team is asking?
+      placeholder: e.g., Audiences, Connections

--- a/.github/ISSUE_TEMPLATE/general-question.yml
+++ b/.github/ISSUE_TEMPLATE/general-question.yml
@@ -7,7 +7,7 @@ body:
       value: |
         ## Question or Discussion
 
-        For quick questions, you can also reach us in the [Aquarium GChat space](https://chat.google.com/room/AAQADRm8Au8?cls=7).
+        For quick questions, you can also reach us in the internal Aquarium GChat space.
 
   - type: textarea
     id: question

--- a/.github/ISSUE_TEMPLATE/icon-request.yml
+++ b/.github/ISSUE_TEMPLATE/icon-request.yml
@@ -1,0 +1,57 @@
+name: "\U0001F3A8 Icon Request"
+description: Request a new icon to be added to the library
+labels: ['icon-request', 'enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Request an Icon
+
+        Aquarium supports two icon systems:
+        - **Rokt Icons** (from @untitledui/icons) — used via `<Icon name={RoktIconName} />`
+        - **mParticle Icons** (local SVGs) — used via `<Icon name="icon-name" />`
+
+        Check [existing icons in Storybook](https://mparticle.github.io/aquarium/?path=/docs/foundations-icons-rokt-icons--documentation) before requesting.
+
+  - type: input
+    id: icon-name
+    attributes:
+      label: Icon Name
+      description: What should the icon be called?
+      placeholder: e.g., PauseCircle, ChartBar, UserPlus
+    validations:
+      required: true
+
+  - type: dropdown
+    id: icon-source
+    attributes:
+      label: Icon Source
+      description: Where does this icon come from?
+      options:
+        - 'Untitled UI / Rokt icon set (preferred)'
+        - 'Custom SVG from Figma'
+        - 'Other / not sure'
+    validations:
+      required: true
+
+  - type: input
+    id: figma-link
+    attributes:
+      label: Figma Link
+      description: Link to the icon in Figma (if available)
+      placeholder: https://www.figma.com/design/...
+
+  - type: textarea
+    id: svg-file
+    attributes:
+      label: SVG File (if custom)
+      description: Paste the SVG markup or drag-and-drop the SVG file
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Where will this icon be used?
+      description: Which product/feature needs this icon?
+      placeholder: e.g., Navigation sidebar in Audiences, action button in Connections table
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,3 @@
-## Instructions
-
-> No need to keep instructions in the final PR description
-
-1. PR target branch should be against `main`
-2. PR title prefix should state semantic value for the change, usually `feat:`, `fix:` or `chore:`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml)
-3. PR branch prefix should state the same as the above with a `/`, usually `feat/`, `fix/` or `chore/`. [Source.](https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml)
-
 ## Summary
 
 - {provide a thorough description of the changes}
@@ -14,3 +6,11 @@
 
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}
+
+---
+
+**PR conventions:**
+
+- Target branch: `main`
+- PR title: semantic prefix — `feat:`, `fix:`, or `chore:` (no scopes)
+- Branch prefix: matching — `feat/`, `fix/`, or `chore/`

--- a/ADOPTING.md
+++ b/ADOPTING.md
@@ -1,0 +1,111 @@
+# Adopting Aquarium
+
+A step-by-step guide for Rokt teams adopting Aquarium as their UI component library.
+
+## Why Aquarium?
+
+Aquarium is Rokt's shared React component library built on [Ant Design](https://ant.design/). It provides:
+
+- **76+ production-ready components** — from buttons to complex data tables
+- **Rokt design tokens** — consistent colors, spacing, typography across products
+- **Storybook documentation** — live examples and API references at [mparticle.github.io/aquarium](https://mparticle.github.io/aquarium/)
+- **AI-native development** — Claude Code skills, LLM setup prompts, and Figma-to-code workflows built in
+
+Using Aquarium instead of raw Ant Design or ad hoc components means fixes propagate everywhere, onboarding is faster, and AI tools generate Rokt-standard code instead of generic patterns.
+
+## Step 1: Install
+
+```bash
+npm install @mparticle/aquarium antd@6 dayjs@1
+```
+
+Add the CSS reset in your app entry point:
+
+```typescript
+import 'antd/dist/reset.css'
+```
+
+## Step 2: Set Up AI Tooling
+
+Aquarium is designed for AI-assisted development. Set up your tools to default to Aquarium components instead of raw HTML or generic libraries.
+
+### Claude Code
+
+If your project uses Claude Code, add this to your project's `CLAUDE.md`:
+
+```markdown
+## UI Components
+
+Use `@mparticle/aquarium` for all UI components. Do NOT import directly from `antd`.
+
+- Components: `import { Button, Table, Select } from '@mparticle/aquarium'`
+- Design tokens: `import { PaddingLg, ColorPrimary } from '@mparticle/aquarium/dist/style'`
+- Icons: `import { RoktPauseCircle } from '@mparticle/aquarium'` for Rokt icons
+- Layout: Use `<Flex>`, `<Center>`, `<Space>` instead of `<div>` with inline styles
+- Reference: https://mparticle.github.io/aquarium/
+```
+
+### Cursor
+
+Add the same guidance to your `.cursor/rules/` directory so Cursor AI generates Aquarium imports.
+
+### LLM Setup Prompt
+
+For any AI tool, paste the contents of [LLM_SETUP_PROMPT.md](LLM_SETUP_PROMPT.md) into your project context. This teaches the model about Aquarium's API surface and conventions.
+
+## Step 3: Migrate from Raw Ant Design
+
+If your project already imports from `antd` directly, migrate incrementally:
+
+```diff
+- import { Button, Table } from 'antd'
++ import { Button, Table } from '@mparticle/aquarium'
+```
+
+Most Aquarium components are thin wrappers around Ant Design with Rokt theming applied, so the API is the same. Check [Storybook](https://mparticle.github.io/aquarium/) for any Aquarium-specific props.
+
+### Common replacements
+
+| Instead of                                                    | Use                                      |
+| ------------------------------------------------------------- | ---------------------------------------- |
+| `<div style={{ display: 'flex' }}>`                           | `<Flex>`                                 |
+| `<div style={{ display: 'flex', justifyContent: 'center' }}>` | `<Center>`                               |
+| `padding: '24px'`                                             | `PaddingLg` from design tokens           |
+| `color: '#3600d1'`                                            | `ColorPrimary` from design tokens        |
+| Custom modal wrapper                                          | `<DeleteConfirmModal>` or `<ErrorModal>` |
+
+## Step 4: Request Missing Components
+
+If Aquarium doesn't have a component you need:
+
+1. **Check first** — browse [Storybook](https://mparticle.github.io/aquarium/) and [Ant Design docs](https://ant.design/components/overview/) to see if an existing component can be configured for your use case
+2. **Open a request** — [Component Request](https://github.com/mParticle/aquarium/issues/new?template=component-request.yml) on GitHub Issues
+3. **Include context** — Figma link, use case, and which product needs it
+
+Requests are triaged automatically and prioritized by impact across teams.
+
+## Step 5: Stay Connected
+
+- **GChat**: [Aquarium space](https://chat.google.com/room/AAQADRm8Au8?cls=7) for weekly updates
+- **GitHub Issues**: [Request components](https://github.com/mParticle/aquarium/issues/new/choose), report bugs, ask questions
+- **Storybook**: [Browse docs](https://mparticle.github.io/aquarium/) for API references and live examples
+
+## FAQ
+
+### Can I still use Ant Design components directly?
+
+Yes, `antd` is a peer dependency. But prefer Aquarium's wrapped version when available — it includes Rokt theming and design tokens. If you need a component Aquarium doesn't wrap yet, use `antd` directly and [open a request](https://github.com/mParticle/aquarium/issues/new?template=component-request.yml) so it can be added.
+
+### How do I contribute a component back?
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). The fastest path is:
+
+```
+/implement-ticket <JIRA-ID>
+```
+
+This uses Claude Code to handle branching, implementation, testing, and PR creation end-to-end.
+
+### What if I need a component urgently?
+
+Mark your [Component Request](https://github.com/mParticle/aquarium/issues/new?template=component-request.yml) as "Blocking — can't ship without it" and note your timeline. Adoption blockers get priority triage.

--- a/ADOPTING.md
+++ b/ADOPTING.md
@@ -86,7 +86,7 @@ Requests are triaged automatically and prioritized by impact across teams.
 
 ## Step 5: Stay Connected
 
-- **GChat**: [Aquarium space](https://chat.google.com/room/AAQADRm8Au8?cls=7) for weekly updates
+- **GChat**: Join the internal Aquarium space for weekly updates
 - **GitHub Issues**: [Request components](https://github.com/mParticle/aquarium/issues/new/choose), report bugs, ask questions
 - **Storybook**: [Browse docs](https://mparticle.github.io/aquarium/) for API references and live examples
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Please make sure any new or updated components are present, tested and verified 
 
 ## Support
 
-- [Aquarium GChat Space](https://chat.google.com/room/AAQADRm8Au8?cls=7) — weekly updates and discussions
-- [GitHub Issues](https://github.com/mParticle/aquarium/issues/new/choose) — component requests, bug reports, questions
+- **Internal**: Join the Aquarium GChat space for weekly updates and discussions
+- **Public**: [GitHub Issues](https://github.com/mParticle/aquarium/issues/new/choose) — component requests, bug reports, questions
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <a href="https://mparticle.github.io/aquarium/" target="_blank"><img src="https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg"></a>
 &nbsp;&nbsp;
 
-# mParticle Aquarium
+# Aquarium — Rokt UI Library
 
-mParticle Component Library built on top of [Ant Design](https://ant.design/).
+Component library for Rokt applications, built on top of [Ant Design](https://ant.design/).
 
 _Components That Scale_
 
@@ -63,6 +63,14 @@ export const MyComponent = () => {
 }
 ```
 
+## Adopting Aquarium
+
+New to Aquarium? See [ADOPTING.md](ADOPTING.md) for a step-by-step onboarding guide.
+
+## Requesting Components
+
+Need a component that doesn't exist yet? [Open a Component Request](https://github.com/mParticle/aquarium/issues/new?template=component-request.yml) on GitHub Issues.
+
 ## Development
 
 Clone the repository and install dependencies:
@@ -93,8 +101,9 @@ Please make sure any new or updated components are present, tested and verified 
 
 ## Support
 
-<support@mparticle.com>
+- [Aquarium GChat Space](https://chat.google.com/room/AAQADRm8Au8?cls=7) — weekly updates and discussions
+- [GitHub Issues](https://github.com/mParticle/aquarium/issues/new/choose) — component requests, bug reports, questions
 
 ## License
 
-mParticle's Aquarium is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). See the LICENSE file for more info.
+Aquarium is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). See the LICENSE file for more info.

--- a/docs/About/Feedback.mdx
+++ b/docs/About/Feedback.mdx
@@ -1,5 +1,20 @@
 # How to Provide Feedback
 
-We’re constantly working to improve our UI Library, and your feedback is invaluable in making it better. Whether you’ve encountered an issue, have suggestions for new components, or just want to share your experience, we’d love to hear from you!
+We’re constantly working to improve the Rokt UI Library, and your feedback is invaluable in making it better. Whether you’ve encountered a bug, need a new component, or want to share your experience, we’d love to hear from you!
 
-To provide feedback, drop your thoughts directly in the `#aquarium` channel on Slack. We review all submissions carefully and appreciate your time!
+## GitHub Issues (preferred)
+
+Use our structured issue templates for trackable, triaged requests:
+
+- **[Request a Component](https://github.com/mParticle/aquarium/issues/new?template=component-request.yml)** — need a component that doesn’t exist yet?
+- **[Report a Bug](https://github.com/mParticle/aquarium/issues/new?template=bug-report.yml)** — something broken or behaving unexpectedly?
+- **[Request an Icon](https://github.com/mParticle/aquarium/issues/new?template=icon-request.yml)** — need a new Rokt or custom icon?
+- **[Ask a Question](https://github.com/mParticle/aquarium/issues/new?template=general-question.yml)** — usage patterns, migration help, theming, AI tooling
+
+## GChat
+
+For quick discussions and weekly updates, join the [Aquarium GChat space](https://chat.google.com/room/AAQADRm8Au8?cls=7).
+
+## Contributing
+
+Want to contribute a component or fix yourself? See the [Contributing guide](?path=/docs/contributing-release-process--documentation) or run `/implement-ticket <JIRA-ID>` in Claude Code for an end-to-end AI-assisted workflow.

--- a/docs/About/Feedback.mdx
+++ b/docs/About/Feedback.mdx
@@ -13,7 +13,7 @@ Use our structured issue templates for trackable, triaged requests:
 
 ## GChat
 
-For quick discussions and weekly updates, join the [Aquarium GChat space](https://chat.google.com/room/AAQADRm8Au8?cls=7).
+For quick discussions and weekly updates, join the internal Aquarium GChat space.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add 4 structured GitHub Issue templates: Component Request, Bug Report, Icon Request, and General Question — giving teams a clear intake path for the first time
- Add `ADOPTING.md` — an AI-first onboarding guide for new Rokt teams (Claude Code, Cursor, LLM setup, migration from raw antd)
- Rebrand README from "mParticle Aquarium" to "Aquarium — Rokt UI Library" with updated support channels (GChat + GitHub Issues)
- Update PR template to remove stale mParticle workflow links and inline current conventions
- Created 6 new GitHub labels for triage: `component-request`, `icon-request`, `adoption-blocker`, `needs-design`, `ai-triaged`, `good-first-component`

Supports the RFC to formalize Aquarium as the default starting point for new React UI at Rokt.

## Test plan

- [ ] Verify issue templates render correctly: go to [Issues > New Issue](https://github.com/mParticle/aquarium/issues/new/choose) and confirm all 4 forms appear
- [ ] Verify labels exist on the repo's [Labels page](https://github.com/mParticle/aquarium/labels)
- [ ] Review ADOPTING.md content for accuracy and completeness
- [ ] Confirm PR template renders correctly on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)