### PR TITLE
fix: form component to preserve static member types in declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "2.3.0",
+  "version": "2.4.0-fix-form-static-member-types.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/aquarium",
-      "version": "2.3.0",
+      "version": "2.4.0-fix-form-static-member-types.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource/courier-prime": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/aquarium",
-  "version": "2.3.0",
+  "version": "2.4.0-fix-form-static-member-types.1",
   "description": "mParticle Component Library",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/components/data-entry/Form/Form.stories.tsx
+++ b/src/components/data-entry/Form/Form.stories.tsx
@@ -1,5 +1,169 @@
 import { type Meta, type StoryObj } from '@storybook/react'
+import { expect, userEvent, within } from 'storybook/test'
+import { Button, Flex, Icon, Input, Typography } from 'src/components'
 import { Form } from 'src/components/data-entry/Form/Form'
+import { SizeSm, SizeXs } from 'src/styles/style'
+
+interface IFormValues {
+  name?: string
+  products?: Array<{ sku?: string }>
+  submittedSummary?: string
+}
+
+const basicFormExampleCode = `import { Button, Flex, Form, Icon, Input, Typography } from '@mparticle/aquarium'
+import { SizeSm, SizeXs } from '@mparticle/aquarium/dist/style'
+
+interface IFormValues {
+  name?: string
+  products?: Array<{ sku?: string }>
+  submittedSummary?: string
+}
+
+const FormInstanceStatus = () => {
+  const form = Form.useFormInstance<IFormValues>()
+  const name = Form.useWatch('name', { form, preserve: true })
+
+  return <Typography.Text type="secondary">{name ? 'Name: ' + name : 'Name not entered'}</Typography.Text>
+}
+
+export const BasicFormExample = () => {
+  const [form] = Form.useForm<IFormValues>()
+  const submittedSummary = Form.useWatch('submittedSummary', { form, preserve: true })
+
+  return (
+    <Form.Provider>
+      <Form
+        form={form}
+        layout="vertical"
+        name="basic-form"
+        initialValues={{ products: [{ sku: '' }] }}
+        onFinish={values => {
+          const skuCount = values.products?.filter(product => product?.sku).length ?? 0
+          form.setFieldValue(
+            'submittedSummary',
+            \`Submitted \${values.name} with \${skuCount} SKU\${skuCount === 1 ? '' : 's'}\`,
+          )
+        }}>
+        <Flex vertical gap={SizeSm} style={{ maxWidth: 360 }}>
+          <Form.Item<IFormValues>
+            label="Name"
+            name="name"
+            rules={[{ required: true, message: 'Name is required' }]}
+            style={{ marginBottom: 0 }}>
+            <Input aria-label="Name" placeholder="Name" />
+          </Form.Item>
+          <FormInstanceStatus />
+          <Form.Item label="Product SKUs" style={{ marginBottom: 0 }}>
+            <Form.List name="products">
+              {(fields, { add, remove }) => (
+                <Flex vertical gap={SizeXs}>
+                  {fields.map(field => (
+                    <Flex key={field.key} align="center" gap={SizeXs}>
+                      <Form.Item noStyle name={[field.name, 'sku']}>
+                        <Input aria-label={\`SKU \${field.name + 1}\`} placeholder={\`SKU \${field.name + 1}\`} />
+                      </Form.Item>
+                      {fields.length > 1 && (
+                        <Button
+                          aria-label={\`Remove SKU \${field.name + 1}\`}
+                          htmlType="button"
+                          icon={<Icon name="delete" size="md" />}
+                          onClick={() => remove(field.name)}
+                        />
+                      )}
+                    </Flex>
+                  ))}
+                  <Button htmlType="button" icon={<Icon name="add" size="md" />} onClick={() => add({ sku: '' })}>
+                    Add SKU
+                  </Button>
+                </Flex>
+              )}
+            </Form.List>
+          </Form.Item>
+          <Form.ErrorList errors={[]} />
+          <Button htmlType="submit" type="primary" style={{ alignSelf: 'flex-start' }}>
+            Save
+          </Button>
+          {submittedSummary && <Typography.Text>{submittedSummary}</Typography.Text>}
+        </Flex>
+      </Form>
+    </Form.Provider>
+  )
+}`
+
+const FormInstanceStatus = () => {
+  const form = Form.useFormInstance<IFormValues>()
+  const name = Form.useWatch('name', { form, preserve: true })
+
+  return (
+    <Typography.Text data-testid="watched-name" type="secondary">
+      {name ? `Name: ${name}` : 'Name not entered'}
+    </Typography.Text>
+  )
+}
+
+const BasicFormExample = () => {
+  const [form] = Form.useForm<IFormValues>()
+  const submittedSummary = Form.useWatch('submittedSummary', { form, preserve: true })
+
+  return (
+    <Form.Provider>
+      <Form
+        form={form}
+        layout="vertical"
+        name="basic-form"
+        initialValues={{ products: [{ sku: '' }] }}
+        onFinish={values => {
+          const skuCount = values.products?.filter(product => product?.sku).length ?? 0
+          form.setFieldValue(
+            'submittedSummary',
+            `Submitted ${values.name} with ${skuCount} SKU${skuCount === 1 ? '' : 's'}`,
+          )
+        }}>
+        <Flex vertical gap={SizeSm} style={{ maxWidth: 360 }}>
+          <Form.Item<IFormValues>
+            label="Name"
+            name="name"
+            rules={[{ required: true, message: 'Name is required' }]}
+            style={{ marginBottom: 0 }}>
+            <Input aria-label="Name" placeholder="Name" />
+          </Form.Item>
+          <FormInstanceStatus />
+          <Form.Item label="Product SKUs" style={{ marginBottom: 0 }}>
+            <Form.List name="products">
+              {(fields, { add, remove }) => (
+                <Flex vertical gap={SizeXs}>
+                  {fields.map(field => (
+                    <Flex key={field.key} align="center" gap={SizeXs}>
+                      <Form.Item noStyle name={[field.name, 'sku']}>
+                        <Input aria-label={`SKU ${field.name + 1}`} placeholder={`SKU ${field.name + 1}`} />
+                      </Form.Item>
+                      {fields.length > 1 && (
+                        <Button
+                          aria-label={`Remove SKU ${field.name + 1}`}
+                          htmlType="button"
+                          icon={<Icon name="delete" size="md" />}
+                          onClick={() => remove(field.name)}
+                        />
+                      )}
+                    </Flex>
+                  ))}
+                  <Button htmlType="button" icon={<Icon name="add" size="md" />} onClick={() => add({ sku: '' })}>
+                    Add SKU
+                  </Button>
+                </Flex>
+              )}
+            </Form.List>
+          </Form.Item>
+          <Form.ErrorList errors={[]} />
+          <Button htmlType="submit" type="primary" style={{ alignSelf: 'flex-start' }}>
+            Save
+          </Button>
+          {submittedSummary && <Typography.Text data-testid="submitted-summary">{submittedSummary}</Typography.Text>}
+        </Flex>
+      </Form>
+    </Form.Provider>
+  )
+}
 
 const meta: Meta<typeof Form> = {
   title: 'Components/Data Entry/Form',
@@ -11,4 +175,41 @@ export default meta
 
 type Story = StoryObj<typeof Form>
 
-export const Primary: Story = {}
+export const Primary: Story = {
+  render: () => <BasicFormExample />,
+  parameters: {
+    docs: {
+      source: {
+        code: basicFormExampleCode,
+        language: 'tsx',
+      },
+    },
+  },
+}
+
+export const StaticMembersValidation: Story = {
+  tags: ['!dev', 'play-test-validation'],
+  render: () => <BasicFormExample />,
+  play: async ({ canvasElement }) => {
+    await expect(typeof Form.useForm).toBe('function')
+    await expect(typeof Form.useWatch).toBe('function')
+    await expect(typeof Form.useFormInstance).toBe('function')
+    await expect(typeof Form.Item).toBe('function')
+    await expect(typeof Form.List).toBe('function')
+    await expect(typeof Form.Provider).toBe('function')
+    await expect(typeof Form.ErrorList).toBe('function')
+
+    const canvas = within(canvasElement)
+
+    await userEvent.type(canvas.getByLabelText('Name'), 'Ada Lovelace')
+    await expect(canvas.getByTestId('watched-name')).toHaveTextContent('Name: Ada Lovelace')
+
+    await userEvent.type(canvas.getByLabelText('SKU 1'), 'SKU-123')
+    await userEvent.click(canvas.getByRole('button', { name: 'Add SKU' }))
+    await userEvent.type(canvas.getByLabelText('SKU 2'), 'SKU-456')
+    await expect(canvas.getByRole('button', { name: 'Remove SKU 2' })).toBeInTheDocument()
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }))
+
+    await expect(canvas.getByTestId('submitted-summary')).toHaveTextContent('Submitted Ada Lovelace with 2 SKUs')
+  },
+}

--- a/src/components/data-entry/Form/Form.tsx
+++ b/src/components/data-entry/Form/Form.tsx
@@ -8,7 +8,7 @@ export interface IFormProps<Values = any> extends AntFormProps<Values> {
   children: ReactNode
 }
 
-export const Form = <Values = any,>(props: IFormProps<Values>) => {
+const InternalForm = <Values = any,>(props: IFormProps<Values>) => {
   return (
     <ConfigProvider>
       <AntForm {...props}>{props.children}</AntForm>
@@ -16,11 +16,22 @@ export const Form = <Values = any,>(props: IFormProps<Values>) => {
   )
 }
 
-Form.useForm = AntForm.useForm
-Form.useWatch = AntForm.useWatch
-Form.useFormInstance = AntForm.useFormInstance
+type FormComponent = typeof InternalForm & {
+  useForm: typeof AntForm.useForm
+  useWatch: typeof AntForm.useWatch
+  useFormInstance: typeof AntForm.useFormInstance
+  Item: typeof AntForm.Item
+  List: typeof AntForm.List
+  Provider: typeof AntForm.Provider
+  ErrorList: typeof AntForm.ErrorList
+}
 
-Form.Item = AntForm.Item
-Form.List = AntForm.List
-Form.Provider = AntForm.Provider
-Form.ErrorList = AntForm.ErrorList
+export const Form: FormComponent = Object.assign(InternalForm, {
+  useForm: AntForm.useForm,
+  useWatch: AntForm.useWatch,
+  useFormInstance: AntForm.useFormInstance,
+  Item: AntForm.Item,
+  List: AntForm.List,
+  Provider: AntForm.Provider,
+  ErrorList: AntForm.ErrorList,
+})


### PR DESCRIPTION
#agentic

## Summary / Timeline (i, wallace wrote this)
- attempts to upgrade from 1.65 to 2.3.x
- sees that `Form.useForm` and `Form.useWatch` both evaluate to `any` due to types not resolving correctly from the `.d.ts` file
- sends codex to fix
- results in this PR; pls approve
<img width="489" height="274" alt="image" src="https://github.com/user-attachments/assets/2c3bfbe0-43d6-4656-b5b6-991ddfa75c27" />


## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- {explain how this has been tested, and what, if any, additional testing should be done}

---

**PR conventions:**

- Target branch: `main`
- PR title: semantic prefix — `feat:`, `fix:`, or `chore:` (no scopes)
- Branch prefix: matching — `feat/`, `fix/`, or `chore/`
