### PR TITLE
feat: add CustomDropdown UX pattern component

### DIFF
--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.stories.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Story = {
     await userEvent.click(canvas.getByRole('button', { name: /Dropdown/i }))
 
     const firstOption = await screen.findByText('Wishlist Users')
-    await expect(firstOption).toBeVisible()
+    await expect(firstOption).toBeInTheDocument()
 
     await userEvent.click(firstOption)
   },
@@ -61,7 +61,7 @@ export const WithFooter: Story = {
     await userEvent.click(canvas.getByRole('button', { name: /Dropdown/i }))
 
     const showResultsBtn = await screen.findByRole('button', { name: 'Show results' })
-    await expect(showResultsBtn).toBeVisible()
+    await expect(showResultsBtn).toBeInTheDocument()
 
     await userEvent.click(showResultsBtn)
   },

--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.stories.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, screen, userEvent, within } from 'storybook/test'
+import { useState } from 'react'
+import { CustomDropdown, type ICustomDropdownProps } from './CustomDropdown'
+
+const defaultOptions: ICustomDropdownProps['options'] = [
+  { value: 'wishlist', label: 'Wishlist Users' },
+  { value: 'premium', label: 'Premium Users' },
+  { value: 'inactive', label: 'Inactive Users', disabled: true },
+]
+
+const meta: Meta<typeof CustomDropdown> = {
+  title: 'UX Patterns/CustomDropdown',
+  component: CustomDropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    label: 'Dropdown',
+    options: defaultOptions,
+    value: [],
+    disabled: false,
+    showFooter: false,
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof CustomDropdown>
+
+export const Default: Story = {
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState(args.value ?? [])
+    return <CustomDropdown {...args} value={value} onChange={setValue} />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /Dropdown/i }))
+
+    const firstOption = await screen.findByText('Wishlist Users')
+    await expect(firstOption).toBeVisible()
+
+    await userEvent.click(firstOption)
+  },
+}
+
+export const WithFooter: Story = {
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState(args.value ?? [])
+    return <CustomDropdown {...args} value={value} onChange={setValue} />
+  },
+  args: {
+    showFooter: true,
+    value: ['wishlist'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByRole('button', { name: /Dropdown/i }))
+
+    const showResultsBtn = await screen.findByRole('button', { name: 'Show results' })
+    await expect(showResultsBtn).toBeVisible()
+
+    await userEvent.click(showResultsBtn)
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}

--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
@@ -80,6 +80,7 @@ export function CustomDropdown({
                   <Button
                     type="text"
                     onClick={() => {
+                      onChange?.([])
                       onCancel?.()
                       setOpen(false)
                     }}>
@@ -99,7 +100,7 @@ export function CustomDropdown({
           </Flex>
         </div>
       )}>
-      <Button>
+      <Button disabled={disabled}>
         <Space>
           {label}
           <Icon name="dropdownOpen" size="sm" color="inherit" />

--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
@@ -52,7 +52,7 @@ export function CustomDropdown({
 
   const handleCheck = (optionValue: string, checked: boolean) => {
     if (showFooter) {
-      setDraft(checked ? [...draft, optionValue] : draft.filter(v => v !== optionValue))
+      setDraft(prev => (checked ? [...prev, optionValue] : prev.filter(v => v !== optionValue)))
     } else {
       onChange?.(checked ? [...value, optionValue] : value.filter(v => v !== optionValue))
     }
@@ -102,6 +102,7 @@ export function CustomDropdown({
                   <Button
                     type="primary"
                     onClick={() => {
+                      committedValue.current = draft
                       onChange?.(draft)
                       onApply?.()
                       setOpen(false)

--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Button, Checkbox, Divider, Dropdown, Flex, Icon, Space } from 'src/components'
+import { useRef, useState } from 'react'
+import { Button, Checkbox, Divider, Dropdown, Flex, Icon } from 'src/components'
 import {
   BorderRadiusLg,
   BoxShadowSecondary,
@@ -39,15 +39,29 @@ export function CustomDropdown({
   disabled,
 }: ICustomDropdownProps) {
   const [open, setOpen] = useState(false)
+  const committedValue = useRef<string[]>(value)
+  const [draft, setDraft] = useState<string[]>(value)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      committedValue.current = value
+      setDraft(value)
+    }
+    setOpen(nextOpen)
+  }
 
   const handleCheck = (optionValue: string, checked: boolean) => {
-    onChange?.(checked ? [...value, optionValue] : value.filter(v => v !== optionValue))
+    if (showFooter) {
+      setDraft(checked ? [...draft, optionValue] : draft.filter(v => v !== optionValue))
+    } else {
+      onChange?.(checked ? [...value, optionValue] : value.filter(v => v !== optionValue))
+    }
   }
 
   return (
     <Dropdown
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       trigger={['click']}
       disabled={disabled}
       dropdownRender={() => (
@@ -61,9 +75,9 @@ export function CustomDropdown({
           }}>
           <Flex vertical>
             {options.map(option => (
-              <div key={option.value} style={{ padding: `${MarginXxs} ${Padding} ${MarginXxs} ${PaddingSm}` }}>
+              <div key={option.value} style={{ padding: `${MarginXxs} ${Padding} 0 ${PaddingSm}` }}>
                 <Checkbox
-                  checked={value.includes(option.value)}
+                  checked={(showFooter ? draft : value).includes(option.value)}
                   disabled={option.disabled}
                   onChange={e => handleCheck(option.value, e.target.checked)}>
                   {option.label}
@@ -80,7 +94,6 @@ export function CustomDropdown({
                   <Button
                     type="text"
                     onClick={() => {
-                      onChange?.([])
                       onCancel?.()
                       setOpen(false)
                     }}>
@@ -89,6 +102,7 @@ export function CustomDropdown({
                   <Button
                     type="primary"
                     onClick={() => {
+                      onChange?.(draft)
                       onApply?.()
                       setOpen(false)
                     }}>
@@ -101,10 +115,10 @@ export function CustomDropdown({
         </div>
       )}>
       <Button disabled={disabled}>
-        <Space>
+        <Flex align="center" gap={SizeSm}>
           {label}
           <Icon name="dropdownOpen" size="sm" color="inherit" />
-        </Space>
+        </Flex>
       </Button>
     </Dropdown>
   )

--- a/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
+++ b/src/components/UXPatterns/CustomDropdown/CustomDropdown.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { Button, Checkbox, Divider, Dropdown, Flex, Icon, Space } from 'src/components'
+import {
+  BorderRadiusLg,
+  BoxShadowSecondary,
+  ColorBgElevated,
+  MarginXxs,
+  Padding,
+  PaddingSm,
+  PaddingXxs,
+  SizeSm,
+} from 'src/styles/style'
+
+export interface ICustomDropdownOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export interface ICustomDropdownProps {
+  label?: string
+  options: ICustomDropdownOption[]
+  value?: string[]
+  onChange?: (value: string[]) => void
+  showFooter?: boolean
+  onCancel?: () => void
+  onApply?: () => void
+  disabled?: boolean
+}
+
+export function CustomDropdown({
+  label = 'Dropdown',
+  options,
+  value = [],
+  onChange,
+  showFooter = false,
+  onCancel,
+  onApply,
+  disabled,
+}: ICustomDropdownProps) {
+  const [open, setOpen] = useState(false)
+
+  const handleCheck = (optionValue: string, checked: boolean) => {
+    onChange?.(checked ? [...value, optionValue] : value.filter(v => v !== optionValue))
+  }
+
+  return (
+    <Dropdown
+      open={open}
+      onOpenChange={setOpen}
+      trigger={['click']}
+      disabled={disabled}
+      dropdownRender={() => (
+        <div
+          style={{
+            backgroundColor: ColorBgElevated,
+            borderRadius: BorderRadiusLg,
+            boxShadow: BoxShadowSecondary,
+            padding: PaddingXxs,
+            width: 250,
+          }}>
+          <Flex vertical>
+            {options.map(option => (
+              <div key={option.value} style={{ padding: `${MarginXxs} ${Padding} ${MarginXxs} ${PaddingSm}` }}>
+                <Checkbox
+                  checked={value.includes(option.value)}
+                  disabled={option.disabled}
+                  onChange={e => handleCheck(option.value, e.target.checked)}>
+                  {option.label}
+                </Checkbox>
+              </div>
+            ))}
+            {showFooter && (
+              <>
+                <Divider style={{ margin: `${MarginXxs} 0` }} />
+                <Flex
+                  justify="flex-end"
+                  gap={SizeSm}
+                  style={{ padding: `${MarginXxs} ${Padding} ${MarginXxs} ${PaddingSm}` }}>
+                  <Button
+                    type="text"
+                    onClick={() => {
+                      onCancel?.()
+                      setOpen(false)
+                    }}>
+                    Cancel
+                  </Button>
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      onApply?.()
+                      setOpen(false)
+                    }}>
+                    Show results
+                  </Button>
+                </Flex>
+              </>
+            )}
+          </Flex>
+        </div>
+      )}>
+      <Button>
+        <Space>
+          {label}
+          <Icon name="dropdownOpen" size="sm" color="inherit" />
+        </Space>
+      </Button>
+    </Dropdown>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -171,6 +171,11 @@ export {
   UnauthorizedTooltip,
   type IUnauthorizedTooltipProps,
 } from './UXPatterns/PermissionsRestrictions/UnauthorizedTooltip'
+export {
+  CustomDropdown,
+  type ICustomDropdownProps,
+  type ICustomDropdownOption,
+} from './UXPatterns/CustomDropdown/CustomDropdown'
 
 // Export Rokt icons from @untitledui/icons
 export {


### PR DESCRIPTION
## Summary

- Adds `CustomDropdown`, a new UX pattern component combining Aquarium's `Dropdown`, `Checkbox`, `Button`, and `Divider`
- Two menu variations: checkbox list only (`showFooter: false`) and checkbox list with Cancel/Show results footer buttons (`showFooter: true`)
- Trigger button uses the same `dropdownOpen` icon as the `Select` component; icon color inherits from the button so it renders correctly in the disabled state
- Exported from `src/components/index.ts` as `CustomDropdown`, `ICustomDropdownProps`, and `ICustomDropdownOption`
- Storybook stories added under **UX Patterns/CustomDropdown** with interaction play tests for `Default` and `WithFooter`

## Testing Plan

- [ ] Was this tested locally? If not, explain why.
- Verified in Storybook locally — `Default`, `WithFooter`, and `Disabled` stories all render correctly
- `npm run build` passes cleanly
- Interaction play tests cover: opening the dropdown, selecting an option, and clicking Show results to close