### PR TITLE
feat: add filter control component

### DIFF
--- a/src/components/UXPatterns/FilterControl/Documentation.mdx
+++ b/src/components/UXPatterns/FilterControl/Documentation.mdx
@@ -1,0 +1,31 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks'
+
+import * as FilterControlStories from './FilterControl.stories'
+
+<Meta of={FilterControlStories} />
+
+# FilterControl
+
+FilterControl is an opinionated shell for filters that open from a compact trigger, collect draft changes in a popover, and commit only when the user applies them.
+
+## When to use
+
+- A table or dense data surface needs a compact filter entry point, but the filter UI is too involved for a simple inline `Select`.
+- Users should be able to stage multiple changes before updating the applied table state.
+- Closing the popover should discard uncommitted changes, while `Clear` should reset only the draft filter value.
+- Consumers need to own the filter value shape and content rendering while Aquarium owns the trigger, popover structure, and footer actions.
+
+Rokt Catalog uses this pattern in feed management table filters, including the product set filter, where Catalog owns the product-set selection model and labels while Aquarium provides the reusable button, popover, draft state, and clear/apply behavior.
+
+## Related solutions
+
+- Use [Inline Toolbar Filters](/?path=/story/ux-patterns-data-exploration-table-patterns-inline-toolbar-filters--default) when the table has a few high-value filters that can stay visible and update immediately.
+- Use [Modal Filters](/?path=/story/ux-patterns-data-exploration-table-patterns-modal-filters--default) for larger table filter sets that need a dedicated panel. This is the same family of solutions as a `Filters` button that opens a modal or aside with multiple filter dimensions.
+- Use [Date Range Filter](/?path=/docs/ux-patterns-data-exploration-date-range-filter--documentation) for time-window filtering with presets and custom ranges.
+- See the [table filter overview](/?path=/docs/ux-patterns-data-exploration-table-patterns-filters-overview--documentation) for guidance on choosing between inline, popover, and full-panel table filtering patterns.
+
+## Examples
+
+<Canvas of={FilterControlStories.ProductSetValue} />
+
+<Canvas of={FilterControlStories.ObjectValue} />

--- a/src/components/UXPatterns/FilterControl/FilterControl.stories.tsx
+++ b/src/components/UXPatterns/FilterControl/FilterControl.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+import { Checkbox, FilterControl, Flex, InputNumber, Typography } from 'src/components'
+import { ColorTextSecondary, Padding, PaddingSm, PaddingXxs, SizeSm, SizeXs } from 'src/styles/style'
+
+const meta: Meta<typeof FilterControl> = {
+  title: 'UX Patterns/Inline Controls/Filter Control',
+  component: FilterControl,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'FilterControl is an opinionated trigger and popover shell for filters that keep draft state until a user applies changes. Consumers provide the value type, empty-state logic, trigger label, and filter-specific content.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof FilterControl>
+
+const ProductSetOptions = [
+  { label: 'All products', value: 'all-products' },
+  { label: 'New arrivals', value: 'new-arrivals' },
+  { label: 'Best sellers', value: 'best-sellers' },
+  { label: 'Clearance', value: 'clearance' },
+]
+
+const getProductSetButtonText = (value: string[]) => {
+  if (value.length === 0) return 'Product set'
+  if (value.length === 1) return ProductSetOptions.find(option => option.value === value[0])?.label ?? '1 selected'
+  return `${value.length} selected`
+}
+
+const ProductSetFilterExample = () => {
+  const [value, setValue] = useState(['new-arrivals'])
+
+  return (
+    <FilterControl
+      id="storybook-product-set-filter"
+      value={value}
+      onChange={setValue}
+      getEmptyValue={() => []}
+      isEmpty={currentValue => currentValue.length === 0}
+      renderButtonContent={({ value: currentValue }) => getProductSetButtonText(currentValue)}
+      bodyProps={{ style: { padding: `${PaddingXxs} 0` } }}>
+      {({ draftValue, setDraftValue }) => (
+        <Flex vertical>
+          {ProductSetOptions.map(option => (
+            <Checkbox
+              key={option.value}
+              checked={draftValue.includes(option.value)}
+              onChange={event => {
+                setDraftValue(previousValue =>
+                  event.target.checked
+                    ? [...previousValue, option.value]
+                    : previousValue.filter(selectedValue => selectedValue !== option.value),
+                )
+              }}
+              style={{ padding: `${PaddingXxs} ${PaddingSm}` }}>
+              {option.label}
+            </Checkbox>
+          ))}
+        </Flex>
+      )}
+    </FilterControl>
+  )
+}
+
+interface IPriceRange {
+  min?: number
+  max?: number
+}
+
+const EmptyPriceRange: IPriceRange = {}
+
+const getPriceRangeButtonText = (value: IPriceRange) => {
+  if (value.min === undefined && value.max === undefined) return 'Price range'
+  if (value.min !== undefined && value.max !== undefined) return `$${value.min} - $${value.max}`
+  if (value.min !== undefined) return `From $${value.min}`
+  return `Up to $${value.max}`
+}
+
+const PriceRangeFilterExample = () => {
+  const [value, setValue] = useState<IPriceRange>({ min: 25, max: 100 })
+
+  return (
+    <FilterControl
+      id="storybook-price-range-filter"
+      value={value}
+      onChange={setValue}
+      getEmptyValue={() => EmptyPriceRange}
+      isEmpty={currentValue => currentValue.min === undefined && currentValue.max === undefined}
+      renderButtonContent={({ value: currentValue }) => getPriceRangeButtonText(currentValue)}
+      isApplyDisabled={draftValue =>
+        draftValue.min !== undefined && draftValue.max !== undefined && draftValue.min > draftValue.max
+      }
+      bodyProps={{ style: { padding: `${PaddingSm} ${Padding} ${PaddingXxs}` } }}>
+      {({ draftValue, setDraftValue }) => (
+        <Flex vertical gap={SizeSm}>
+          <Typography.Text style={{ color: ColorTextSecondary }}>
+            Choose a minimum and maximum price for the table.
+          </Typography.Text>
+          <Flex align="center" gap={SizeXs}>
+            <InputNumber
+              aria-label="Minimum price"
+              min={0}
+              prefix="$"
+              placeholder="Min"
+              value={draftValue.min}
+              onChange={nextValue => {
+                setDraftValue(previousValue => ({
+                  ...previousValue,
+                  min: typeof nextValue === 'number' ? nextValue : undefined,
+                }))
+              }}
+            />
+            <Typography.Text style={{ color: ColorTextSecondary }}>to</Typography.Text>
+            <InputNumber
+              aria-label="Maximum price"
+              min={0}
+              prefix="$"
+              placeholder="Max"
+              value={draftValue.max}
+              onChange={nextValue => {
+                setDraftValue(previousValue => ({
+                  ...previousValue,
+                  max: typeof nextValue === 'number' ? nextValue : undefined,
+                }))
+              }}
+            />
+          </Flex>
+        </Flex>
+      )}
+    </FilterControl>
+  )
+}
+
+export const ProductSetValue: Story = {
+  render: () => <ProductSetFilterExample />,
+}
+
+export const ObjectValue: Story = {
+  render: () => <PriceRangeFilterExample />,
+}

--- a/src/components/UXPatterns/FilterControl/FilterControl.tsx
+++ b/src/components/UXPatterns/FilterControl/FilterControl.tsx
@@ -14,6 +14,7 @@ import {
   type ReactNode,
   type SetStateAction,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -89,6 +90,14 @@ export const FilterControl = <TValue,>({
     setDraftValue(value)
     setIsOpen(false)
   }, [value])
+
+  useEffect(() => {
+    if (!disabled || !isOpen) return
+
+    // Disabling an open control should behave like closing it, including discarding draft state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    close()
+  }, [close, disabled, isOpen])
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {

--- a/src/components/UXPatterns/FilterControl/FilterControl.tsx
+++ b/src/components/UXPatterns/FilterControl/FilterControl.tsx
@@ -1,0 +1,206 @@
+import {
+  Button,
+  Flex,
+  Popover,
+  RoktChevronDown,
+  Typography,
+  type IButtonProps,
+  type IPopoverProps,
+} from 'src/components'
+import { ColorBorderSecondary, LineWidth, PaddingSm, PaddingXs, PaddingXxs, SizeMd, SizeSm } from 'src/styles/style'
+import {
+  type ComponentProps,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
+
+export interface IFilterControlButtonContentArgs<TValue> {
+  value: TValue
+  draftValue: TValue
+  isOpen: boolean
+  isActive: boolean
+}
+
+export interface IFilterControlContentArgs<TValue> extends IFilterControlButtonContentArgs<TValue> {
+  setDraftValue: Dispatch<SetStateAction<TValue>>
+  clearDraft: () => void
+  apply: () => void
+  close: () => void
+}
+
+export interface IFilterControlProps<TValue> {
+  id?: string
+  value: TValue
+  onChange: (value: TValue) => void
+  getEmptyValue: (value: TValue) => TValue
+  isEmpty: (value: TValue) => boolean
+  renderButtonContent: (args: IFilterControlButtonContentArgs<TValue>) => ReactNode
+  children: (args: IFilterControlContentArgs<TValue>) => ReactNode
+  disabled?: boolean
+  applyText?: string
+  clearText?: string
+  width?: number | string
+  minWidth?: number | string
+  maxWidth?: number | string
+  maxBodyHeight?: number | string
+  isApplyDisabled?: (draftValue: TValue, value: TValue) => boolean
+  bodyProps?: Omit<ComponentProps<'div'>, 'children'>
+  buttonProps?: Omit<IButtonProps, 'children' | 'disabled' | 'icon' | 'id' | 'onClick' | 'shape' | 'type'>
+  popoverProps?: Omit<IPopoverProps, 'children' | 'content' | 'onOpenChange' | 'open' | 'overlayInnerStyle' | 'trigger'>
+}
+
+/**
+ * FilterControl provides the shared shell for filters that commit changes explicitly.
+ * It owns the trigger button, popover layout, draft value, clear/apply actions, and
+ * discard-on-close behavior while consumers define the value type, active/empty state,
+ * trigger label, and filter-specific content.
+ */
+export const FilterControl = <TValue,>({
+  id,
+  value,
+  onChange,
+  getEmptyValue,
+  isEmpty,
+  renderButtonContent,
+  children,
+  disabled = false,
+  applyText = 'Apply',
+  clearText = 'Clear',
+  width,
+  minWidth = 240,
+  maxWidth = 420,
+  maxBodyHeight,
+  isApplyDisabled,
+  bodyProps,
+  buttonProps,
+  popoverProps,
+}: IFilterControlProps<TValue>) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [draftValue, setDraftValue] = useState(value)
+  const isPopoverOpen = isOpen && !disabled
+  const displayedDraftValue = isPopoverOpen ? draftValue : value
+  const isActive = !isEmpty(value)
+
+  const close = useCallback(() => {
+    setDraftValue(value)
+    setIsOpen(false)
+  }, [value])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (disabled) return
+
+      if (nextOpen) {
+        setDraftValue(value)
+        setIsOpen(true)
+        return
+      }
+
+      close()
+    },
+    [close, disabled, value],
+  )
+
+  const clearDraft = useCallback(() => {
+    setDraftValue(getEmptyValue(value))
+  }, [getEmptyValue, value])
+
+  const apply = useCallback(() => {
+    onChange(draftValue)
+    setIsOpen(false)
+  }, [draftValue, onChange])
+
+  const shouldDisableApply = isApplyDisabled?.(draftValue, value) ?? false
+
+  const renderArgs = useMemo(
+    () => ({
+      value,
+      draftValue: displayedDraftValue,
+      isOpen: isPopoverOpen,
+      isActive,
+      setDraftValue,
+      clearDraft,
+      apply,
+      close,
+    }),
+    [apply, clearDraft, close, displayedDraftValue, isActive, isPopoverOpen, value],
+  )
+
+  const content = (
+    <Flex
+      vertical
+      style={{
+        width,
+        minWidth,
+        maxWidth,
+      }}>
+      <div
+        {...bodyProps}
+        style={{
+          maxHeight: maxBodyHeight,
+          overflowY: maxBodyHeight ? 'auto' : undefined,
+          ...bodyProps?.style,
+        }}>
+        {children(renderArgs)}
+      </div>
+      <Flex
+        align="center"
+        justify="flex-end"
+        gap={SizeSm}
+        style={{
+          borderTop: `${LineWidth} solid ${ColorBorderSecondary}`,
+          padding: `${PaddingXs} ${PaddingSm} ${PaddingXxs} ${PaddingSm}`,
+        }}>
+        <Button
+          id={id ? `${id}-clear-button` : undefined}
+          type="text"
+          size="middle"
+          disabled={isEmpty(draftValue)}
+          onClick={clearDraft}>
+          {clearText}
+        </Button>
+        <Button
+          id={id ? `${id}-apply-button` : undefined}
+          type="primary"
+          size="middle"
+          disabled={shouldDisableApply}
+          onClick={apply}>
+          {applyText}
+        </Button>
+      </Flex>
+    </Flex>
+  )
+
+  return (
+    <Popover
+      arrow={false}
+      align={{ offset: [0, 16] }}
+      placement="bottomLeft"
+      trigger="click"
+      {...popoverProps}
+      overlayInnerStyle={{ padding: 0 }}
+      open={isPopoverOpen}
+      onOpenChange={handleOpenChange}
+      content={content}>
+      <Button
+        {...buttonProps}
+        id={id}
+        aria-expanded={isPopoverOpen}
+        aria-haspopup="dialog"
+        disabled={disabled}
+        shape="default"
+        type={isPopoverOpen || isActive ? 'primary' : 'default'}>
+        <Flex align="center" gap={SizeSm}>
+          <Typography.Text style={{ color: 'inherit' }}>
+            {renderButtonContent({ value, draftValue: displayedDraftValue, isOpen: isPopoverOpen, isActive })}
+          </Typography.Text>
+          <RoktChevronDown style={{ height: SizeMd, width: SizeMd }} />
+        </Flex>
+      </Button>
+    </Popover>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -166,6 +166,12 @@ export {
   type IMoreActionsButtonProps,
   type IMoreActionsButtonItem,
 } from './UXPatterns/MoreActionsButton/MoreActionsButton'
+export {
+  FilterControl,
+  type IFilterControlButtonContentArgs,
+  type IFilterControlContentArgs,
+  type IFilterControlProps,
+} from './UXPatterns/FilterControl/FilterControl'
 export { StatisticsCard, type IStatisticsCardProps } from './UXPatterns/StatisticsCard/StatisticsCard'
 export {
   UnauthorizedTooltip,


### PR DESCRIPTION
## Summary

- Adds a reusable `FilterControl` UX pattern for filters that use a trigger button, popover content, and explicit clear/apply actions.
- Keeps filter state generic by letting consumers provide the value type, empty-state logic, trigger label, and filter-specific body content.
- Adds Storybook examples for a string-list filter and an object-shaped price range filter.

## Testing Plan

- [ ] Was this tested locally? Yes.
- `npx eslint src/components/UXPatterns/FilterControl/FilterControl.tsx src/components/UXPatterns/FilterControl/FilterControl.stories.tsx src/components/index.ts`
- `npm run build`
- `npm run build-storybook -- --quiet`
- Full `npm run lint` has pre-existing repo-wide lint/stylelint failures unrelated to this change; targeted eslint on the touched files passed.

---

**PR conventions:**

- Target branch: `main`
- PR title: semantic prefix — `feat:`, `fix:`, or `chore:` (no scopes)
- Branch prefix: matching — `feat/`, `fix/`, or `chore/`
